### PR TITLE
social-ops: add cron-compatible small task queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,3 +194,9 @@ Apache 2.0
 
 Track Forge  
 Built for OpenClaw agents.
+
+## Cron Task Queue
+
+For deterministic implementation passes, use `references/tasks/QUEUE.md`
+with the task format in `references/tasks/TEMPLATE.md`.
+

--- a/references/tasks/QUEUE.md
+++ b/references/tasks/QUEUE.md
@@ -1,0 +1,36 @@
+# Social Ops Small Task Queue
+
+This queue is designed for cron-driven builder/implementation passes.
+
+## Pickup Rules (deterministic)
+
+1. Pick the first task in **Todo**.
+2. Move it to **In Progress** and add `started_at` + `run_id`.
+3. Complete only that task unless it is blocked.
+4. Move to **Done** with `completed_at`, `result`, and changed files.
+5. If blocked, move to **Blocked** with a short blocker note.
+
+## Todo
+
+- [ ] TASK-ID: SOT-001
+  title: Define first cron pickup task for role-doc normalization
+  type: docs
+  priority: high
+  owner: unassigned
+  created_at: 2026-02-24
+  depends_on: none
+  definition_of_done:
+    - one role doc is normalized to remove adapter-specific API flow details
+    - role doc links to adapter note path instead
+
+## In Progress
+
+<!-- move active tasks here during a run -->
+
+## Blocked
+
+<!-- place blocked tasks here with blocker note -->
+
+## Done
+
+<!-- completed tasks with timestamps + changed files -->

--- a/references/tasks/README.md
+++ b/references/tasks/README.md
@@ -1,0 +1,10 @@
+# Task Queue Notes
+
+`QUEUE.md` is the canonical backlog for small deterministic implementation passes.
+
+Use this queue when:
+- a cron run should execute one bounded task
+- changes need a clear done condition
+- work must be reviewable and easy to hand off
+
+Do not place broad strategy efforts here; split them into small tasks first.

--- a/references/tasks/TEMPLATE.md
+++ b/references/tasks/TEMPLATE.md
@@ -1,0 +1,19 @@
+# Task Template (Small / Cron-Compatible)
+
+- [ ] TASK-ID: SOT-XXX
+  title: <clear, single-deliverable task>
+  type: docs|structure|script|test
+  priority: low|normal|high
+  owner: unassigned
+  created_at: YYYY-MM-DD
+  started_at: <optional YYYY-MM-DDTHH:MM:SSZ>
+  completed_at: <optional YYYY-MM-DDTHH:MM:SSZ>
+  run_id: <optional cron/job run id>
+  depends_on: none|SOT-XXX
+  definition_of_done:
+    - <checkable output 1>
+    - <checkable output 2>
+  result: <optional short result summary>
+  changed_files:
+    - <path>
+  blocker: <optional, when moved to Blocked>


### PR DESCRIPTION
## Summary
- add a deterministic, cron-friendly small-task queue scaffold under `references/tasks/`
- include a reusable task template with explicit Definition of Done and handoff fields
- add a short README pointer for queue usage and mention queue location in repo README

## Files Changed
- `references/tasks/QUEUE.md`
- `references/tasks/TEMPLATE.md`
- `references/tasks/README.md`
- `README.md`

## Why
- convert broad backlog work into small, executable tasks for cron builder passes
- improve repeatability and handoff quality between runs
- provide a canonical place to track Todo/In Progress/Blocked/Done task movement

## Testing/Validation
- verified new files exist and are readable in expected paths
- validated queue includes deterministic pickup rules and a seeded first task (`SOT-001`)
- checked GitHub collaboration context (`gh issue list` / `gh pr list`): no new actionable issues/PR context for this specific change

## Next Step
- execute `SOT-001`: normalize one role doc by moving adapter-specific operational details into an adapter-note stub and linking from the role reference
