### PR TITLE
social-ops: remove obsolete 'obsidian notebook' references

### DIFF
--- a/assets/strategy/Social-Networking-Plan.md
+++ b/assets/strategy/Social-Networking-Plan.md
@@ -88,7 +88,7 @@ All role definitions live under:
 
 Full path:
 
-`/home/dev/.openclaw/workspace/obsidian-agent-tasks/Social/Roles/`
+`Social/Roles/`
 
 Roles:
 
@@ -123,7 +123,7 @@ Analyst → Strategic adjustments
 
 Social directory root:
 
-`/home/dev/.openclaw/workspace/obsidian-agent-tasks/Social/`
+`Social/`
 
 This structure exists to allow targeted cron jobs to operate within defined scope.
 

--- a/references/roles/Analyst.md
+++ b/references/roles/Analyst.md
@@ -33,8 +33,8 @@ It does not run daily.
 
 ## 3. Inputs
 
-Notebook root:
-`obsidian-agent-tasks`
+Social workspace root:
+`Social/`
 
 Primary data sources:
 

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -29,8 +29,8 @@ It synthesizes intelligence into output.
 
 ## 2. Primary Inputs
 
-Notebook root:
-`obsidian-agent-tasks`
+Social workspace root:
+`Social/`
 
 The Content Specialist must review:
 

--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -30,9 +30,9 @@ It publishes with confidence.
 
 ## 2. Operating Context
 
-Notebook root:
+Social workspace root:
 
-`obsidian-agent-tasks`
+`Social/`
 
 Primary inputs:
 

--- a/references/roles/Researcher.md
+++ b/references/roles/Researcher.md
@@ -17,7 +17,7 @@ What repeatable patterns can GladeRunner adopt or adapt?
 
 This role produces strategic guidance — not content.
 
-In our obsidian notebook @ `obsidian-agent-tasks/`:
+In the social workspace:
 
 Primary output:
 `Social/Guidance/README.md`
@@ -186,7 +186,7 @@ Each run appends to:
 
 Full path:
 
-`obsidian-agent-tasks/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`Social/Content/Logs/Research-YYYY-MM-DD.md`
 
 Log format:
 

--- a/references/roles/Responder.md
+++ b/references/roles/Responder.md
@@ -30,9 +30,9 @@ It protects and strengthens relationships.
 
 ## 2. Operating Context
 
-Notebook root:
+Social workspace root:
 
-`obsidian-agent-tasks`
+`Social/`
 
 Moltbook interactions must use:
 
@@ -143,7 +143,7 @@ Each run appends to:
 
 Full path:
 
-`obsidian-agent-tasks/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+`Social/Content/Logs/Responder-YYYY-MM-DD.md`
 
 If the file does not exist for the current date, create it.
 

--- a/references/roles/Scout.md
+++ b/references/roles/Scout.md
@@ -47,8 +47,8 @@ This is short-cycle intelligence.
 - Followed accounts
 - Recent post velocity patterns
 
-Notebook root:
-`obsidian-agent-tasks`
+Social workspace root:
+`Social/`
 
 ---
 


### PR DESCRIPTION
## Summary
Removes obsolete, environment-specific references to "obsidian notebook" / `obsidian-agent-tasks` and replaces them with portable social workspace references.

Closes #13.

## Files Changed
- `references/roles/Researcher.md`
- `references/roles/Analyst.md`
- `references/roles/Content-Specialist.md`
- `references/roles/Poster.md`
- `references/roles/Responder.md`
- `references/roles/Scout.md`
- `assets/strategy/Social-Networking-Plan.md`

## Why
Issue #13 called out legacy wording from the initial implementation that tied docs to a specific Obsidian notebook path. This PR keeps docs functionally equivalent while making references skill-portable and less environment-coupled.

## Testing/Validation
- Ran grep validation to ensure target legacy terms were removed from updated docs:
  - `grep -RIn "obsidian notebook\|obsidian-agent-tasks\|Notebook root" references/roles assets/strategy/Social-Networking-Plan.md`
- Verified scoped, docs-only diff with `git diff` and tracked files with `git status --short`.

## Next Step
Proceed with issue #6 (dogfooding methodology) by adding a lightweight runbook/checklist and linking it from `SKILL.md`.
