### PR TITLE
Add ClawHub publish workflow (#17)

### DIFF
--- a/.clawignore
+++ b/.clawignore
@@ -1,0 +1,8 @@
+# Files/dirs excluded from ClawHub publish package
+# Used by the CI build step (rsync --exclude-from) and as documentation
+AGENTS.md
+.github/
+.pre-commit-config.yaml
+docs/
+scripts/
+references/tasks/QUEUE.md

--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -1,0 +1,39 @@
+name: Publish to ClawHub
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install ClawHub CLI
+        run: npm i -g clawhub
+
+      - name: Authenticate
+        run: clawhub login --token ${{ secrets.CLAWHUB_API_KEY }} --no-browser
+
+      - name: Build clean package
+        run: |
+          mkdir -p /tmp/publish
+          rsync -a \
+            --exclude-from=.clawignore \
+            --exclude='.git/' \
+            . /tmp/publish/
+
+      - name: Publish to ClawHub
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          clawhub publish /tmp/publish \
+            --slug social-ops \
+            --name "Social Ops" \
+            --version "$VERSION" \
+            --changelog "${{ github.event.release.body }}"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to automatically publish to ClawHub when a release is created.

### Changes
- **`.github/workflows/clawhub-publish.yml`** — Triggers on release published, installs clawhub CLI, authenticates with `CLAWHUB_API_KEY` secret, builds a clean package (excluding dev files), publishes with version from release tag and changelog from release body.
- **`.clawignore`** — Documents files excluded from the publish package. Used as the rsync exclude list in the build step.

### Excluded from publish
- `AGENTS.md` (internal contributor guide)
- `.github/` (CI config)
- `.pre-commit-config.yaml` (dev tooling)
- `docs/` (spike/planning docs)
- `scripts/` (build scripts)
- `references/tasks/QUEUE.md` (WIP task state)

### Note
The `CLAWHUB_API_KEY` repo secret is already configured. Publishing won't work until the repo is public (private repos can't use org secrets on the free plan).

Closes #17