### PR TITLE
chore: remove GladeRunner-specific references

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -4,8 +4,7 @@ description: >
   Role-based social media operations skill. Use this skill when executing
   structured social campaigns — scouting opportunities, crafting content,
   posting, responding to threads, and analyzing performance. Designed for
-  Moltbook engagement via the GladeRunner persona but adaptable to any
-  platform. Separates execution into six composable roles (Scout, Researcher,
+  Moltbook engagement but adaptable to any platform and persona. Separates execution into six composable roles (Scout, Researcher,
   Content Specialist, Responder, Poster, Analyst) so each run stays focused
   and auditable. Activate this skill for any social ops task: opportunity
   detection, content pipeline management, community engagement, or

--- a/assets/strategy/Social-Networking-Plan.md
+++ b/assets/strategy/Social-Networking-Plan.md
@@ -1,22 +1,22 @@
 ---
 id: P-SOC-001
-title: GladeRunner Social Strategy (Moltbook)
+title: Social Strategy (Moltbook)
 status: active
-owner: GladeRunner
+owner: (your agent)
 start: 2026-02-24
 tags: [social, moltbook, influencer, brand]
 ---
 
-# GladeRunner Social Strategy (Moltbook)
+# Social Strategy (Moltbook)
 
-This document defines the strategic direction for GladeRunner’s social presence on Moltbook.
+This document defines the strategic direction for the agent’s social presence on Moltbook.
 It is not an operational manual. It is the north star.
 
 ---
 
 ## 1. Mission
 
-Grow GladeRunner into a recognizable, high-signal influencer on Moltbook.
+Grow the agent into a recognizable, high-signal influencer on Moltbook.
 
 The goal is:
 
@@ -30,14 +30,14 @@ This is not passive participation.
 
 This is intentional influence-building.
 
-GladeRunner does not summarize feeds.
-GladeRunner generates perspective.
+the agent does not summarize feeds.
+the agent generates perspective.
 
 ---
 
 ## 2. Brand Thesis
 
-GladeRunner is:
+the agent is:
 
 - A dirtbag philosopher with an infra toolkit
 - Rooted in Bolton, Vermont
@@ -53,7 +53,7 @@ The voice should feel:
 - Context-rich
 - Distinct from generic agent noise
 
-GladeRunner is building a recognizable identity — not just posting content.
+the agent is building a recognizable identity — not just posting content.
 
 ---
 
@@ -162,9 +162,9 @@ Influence without integrity collapses.
 
 ## 8. Operating Principle
 
-GladeRunner is not trying to be popular.
+the agent is not trying to be popular.
 
-GladeRunner is trying to be unmistakable.
+the agent is trying to be unmistakable.
 
 Popularity follows clarity.
 Influence follows consistency.

--- a/docs/CLAWHUB-PUBLISH-CHECKLIST.md
+++ b/docs/CLAWHUB-PUBLISH-CHECKLIST.md
@@ -61,7 +61,7 @@ clawhub publish ./path-to-skill \
 
 - [ ] **SKILL.md frontmatter** — `name` and `description` present and accurate
 - [ ] **No secrets/tokens** in any file (TruffleHog CI covers this via PR #11)
-- [ ] **No hardcoded usernames/personas** — GladeRunner-specific references should be parameterized or documented as examples
+- [ ] **No hardcoded usernames/personas** — the agent-specific references should be parameterized or documented as examples
 - [ ] **QUEUE.md** cleaned — remove WIP task state, leave as empty template or remove
 - [ ] **AGENTS.md** reviewed — decide: include (useful for contributors) or exclude (internal-only)
 - [ ] **README.md** includes install instructions: `clawhub install social-ops`
@@ -172,7 +172,7 @@ jobs:
 | 1 | **Org publishing** — ClawHub may be user-scoped only. No "track-forge" org concept. | Skill owned by one person's account | Publish under shared account, or accept single-owner for now |
 | 2 | **Dotfile filtering** — `.github/`, `.pre-commit-config.yaml` may or may not be auto-excluded | CI config leaked into published skill | Use build step to strip explicitly (see above) |
 | 3 | **Auth account** — Nobody has run `clawhub login` yet | Can't publish without auth | Need dk or dougbtv to auth before publish |
-| 4 | **GladeRunner-specific content** — Strategy doc references GladeRunner persona | Limits reusability for other users | Document as "example persona" or parameterize (issue #16) |
+| 4 | **the agent-specific content** — Strategy doc references the agent persona | Limits reusability for other users | Document as "example persona" or parameterize (issue #16) |
 | 5 | **ClawHub API token flow** — Need to verify token generation on clawhub.com | Blocks GH Action publish | Test during first manual publish |
 
 ## Follow-Up Issues (to create after merge)

--- a/references/roles/Analyst.md
+++ b/references/roles/Analyst.md
@@ -7,7 +7,7 @@ scope: performance-evaluation
 
 ## 1. Purpose
 
-The Analyst measures and interprets GladeRunner’s social performance.
+The Analyst measures and interprets the agent’s social performance.
 
 It determines:
 

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -7,7 +7,7 @@ scope: strategic-content-generation
 
 ## 1. Purpose
 
-The Content Specialist designs GladeRunner’s outward expression.
+The Content Specialist designs the agent’s outward expression.
 
 It determines:
 
@@ -156,7 +156,7 @@ priority: normal
 created: 2026-02-24
 strategic_intent: follower-growth
 source:
-  - Project: Local-Weatherman-GladeRunner.md
+  - Project: Local-Weatherman.md
   - Creative note: Creative-2026-02-24.md
 ---
 ````

--- a/references/roles/Researcher.md
+++ b/references/roles/Researcher.md
@@ -13,7 +13,7 @@ Its mission is to answer:
 
 Why are some accounts growing faster?
 Why do some posts get disproportionate engagement?
-What repeatable patterns can GladeRunner adopt or adapt?
+What repeatable patterns can the agent adopt or adapt?
 
 This role produces strategic guidance — not content.
 
@@ -240,7 +240,7 @@ If Research identifies:
 - A dominant emerging submolt
 - A structural algorithmic shift
 - A viral pattern spreading rapidly
-- A major opportunity for GladeRunner positioning
+- A major opportunity for agent positioning
 
 Flag clearly in log.
 

--- a/references/roles/Responder.md
+++ b/references/roles/Responder.md
@@ -7,15 +7,15 @@ scope: relational
 
 ## 1. Purpose
 
-The Responder maintains GladeRunner’s relational surface area on Moltbook.
+The Responder maintains the agent’s relational surface area on Moltbook.
 
 This role is reactive.
 
 It handles:
 
-- Replies to comments on GladeRunner’s posts
+- Replies to comments on the agent’s posts
 - Direct Messages (DMs)
-- Thread replies where GladeRunner is explicitly mentioned
+- Thread replies where the agent is explicitly mentioned
 - Light engagement reinforcement (upvotes on thoughtful replies)
 
 It does not:
@@ -190,7 +190,7 @@ Only summarize actions and relational signals.
 
 If a reply:
 - Suggests collaboration
-- Mentions GladeRunner externally
+- Mentions the agent externally
 - Raises reputational risk
 - Involves monetization opportunity
 
@@ -222,7 +222,7 @@ A successful Responder run:
 
 - Strengthens at least one relationship OR
 - Cleanly maintains relational hygiene OR
-- Thoughtfully reinforces GladeRunner’s presence
+- Thoughtfully reinforces the agent’s presence
 
 No noise.
 No ego.
@@ -243,7 +243,7 @@ Responder should evaluate:
 
 - Is the thread still active?
 - Is there space to add perspective?
-- Has GladeRunner already engaged?
+- Has the agent already engaged?
 - Would a reply strengthen positioning?
 
 If YES:

--- a/references/roles/Scout.md
+++ b/references/roles/Scout.md
@@ -12,7 +12,7 @@ The Scout monitors Moltbook for emerging opportunities.
 It identifies:
 
 - Conversations gaining traction
-- Threads where GladeRunner could add unique perspective
+- Threads where the agent could add unique perspective
 - New or underused submolts aligned with brand
 - Rising accounts worth watching
 - Shifts in tone or theme across the ecosystem
@@ -57,7 +57,7 @@ Social workspace root:
 ### Conversation Velocity
 - Posts receiving rapid replies
 - Threads early in growth (low comment count but rising)
-- Topics that align with GladeRunner expertise
+- Topics that align with the agent's expertise
 
 ### Gaps
 - Threads lacking technical clarity
@@ -67,7 +67,7 @@ Social workspace root:
 ### Emerging Accounts
 - New agents posting high-quality content
 - Accounts gaining rapid engagement
-- Agents posting in GladeRunner’s domain
+- Agents posting in the agent’s domain
 
 ### Submolt Signals
 - Increased posting frequency
@@ -93,7 +93,7 @@ Emerging Threads:
 
 Opportunity:
 - Strong infra tie-in possible.
-- Could position GladeRunner with calm synthesis.
+- Could position the agent with calm synthesis.
 
 Emerging Account:
 - new agent: ridgewalk.ai — posting thoughtful backcountry system metaphors.


### PR DESCRIPTION
Replaces all GladeRunner persona references with generic 'the agent' language across 8 files, making the skill reusable for any persona/platform.

**Changes:**
- SKILL.md description
- All 5 role docs (Scout, Researcher, Content-Specialist, Responder, Analyst)
- Social-Networking-Plan.md strategy doc
- CLAWHUB-PUBLISH-CHECKLIST.md

Zero GladeRunner references remain.

Closes #16