### PR TITLE
social-ops: harden clawhub publish against timeout

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -15,7 +15,7 @@ jobs:
           node-version: 20
 
       - name: Install ClawHub CLI
-        run: npm i -g clawhub
+        run: npm i -g clawhub@latest
 
       - name: Authenticate
         run: clawhub login --token ${{ secrets.CLAWHUB_API_KEY }} --no-browser
@@ -32,8 +32,23 @@ jobs:
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           VERSION="${VERSION#v}"
-          clawhub publish /tmp/publish \
-            --slug social-ops \
-            --name "Social Ops" \
-            --version "$VERSION" \
-            --changelog "${{ github.event.release.body }}"
+          CHANGELOG="${{ github.event.release.body || 'Release from GitHub Actions' }}"
+
+          ATTEMPTS=3
+          for attempt in $(seq 1 "$ATTEMPTS"); do
+            echo "Publish attempt ${attempt}/${ATTEMPTS}"
+            if clawhub publish /tmp/publish \
+              --slug social-ops \
+              --name "Social Ops" \
+              --version "$VERSION" \
+              --changelog "$CHANGELOG"; then
+              exit 0
+            fi
+
+            if [ "$attempt" -lt "$ATTEMPTS" ]; then
+              sleep $((attempt * 10))
+            fi
+          done
+
+          echo "ClawHub publish failed after ${ATTEMPTS} attempts"
+          exit 1


### PR DESCRIPTION
Summary
- Fixes the release publish workflow to better handle transient ClawHub publish timeouts seen in issue #22.
- Keeps scope intentionally small: only the publish workflow logic is adjusted.

Files Changed
- .github/workflows/clawhub-publish.yml

Why
- The current release workflow fails at `clawhub publish` with `Timeout` after package preparation.
- Adding retries with short backoff improves reliability for transient network/service latency without changing release semantics.

Testing/Validation
- Reviewed failing run logs from run `22441181063` to confirm timeout failure mode before patching.
- Performed lightweight workflow validation by inspecting generated script logic and ensuring retry/fallback paths are present.
- Verified change set is scoped to one workflow file.

Next Step
- Cut a test release (e.g., v0.0.2) to validate that publish now succeeds end-to-end; if not, capture new logs and open follow-up diagnostics issue.

Refs: #22
