### PR TITLE
social-ops: add timeout tolerance to clawhub publish workflow

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -51,4 +51,13 @@ jobs:
           done
 
           echo "ClawHub publish failed after ${ATTEMPTS} attempts"
-          exit 1
+          
+          # If we timed out, check if the publish actually succeeded
+          echo "Checking if publish succeeded despite timeout..."
+          if clawhub inspect social-ops --json | jq -r '.versions[].tag' | grep -q "^${VERSION}$"; then
+            echo "Version ${VERSION} confirmed published. Exiting successfully."
+            exit 0
+          else
+            echo "Version ${VERSION} not found. Publish likely failed."
+            exit 1
+          fi


### PR DESCRIPTION
Fixes #22\n\nSummary:\n- Added logic to check if a publish actually succeeded despite a timeout error\n- Uses clawhub inspect to verify the expected version was published\n- Only fails the job if the version is truly missing\n\nFiles Changed:\n- .github/workflows/clawhub-publish.yml\n\nWhy:\nThe publish step was failing due to timeouts even when the publish likely succeeded. This was causing releases to fail unnecessarily.\n\nTesting/Validation:\n- Pushed changes to this PR branch\n- Workflow syntax is valid\n\nNext Step:\nMerge this PR to resolve the timeout issue in the publish workflow.