### PR TITLE
social-ops: enhance timeout tolerance in clawhub publish workflow

### DIFF
--- a/.github/workflows/clawhub-publish.yml
+++ b/.github/workflows/clawhub-publish.yml
@@ -37,12 +37,31 @@ jobs:
           ATTEMPTS=3
           for attempt in $(seq 1 "$ATTEMPTS"); do
             echo "Publish attempt ${attempt}/${ATTEMPTS}"
-            if clawhub publish /tmp/publish \
+            
+            # Try to publish with timeout handling
+            if timeout 60s clawhub publish /tmp/publish \
               --slug social-ops \
               --name "Social Ops" \
               --version "$VERSION" \
               --changelog "$CHANGELOG"; then
               exit 0
+            else
+              EXIT_CODE=$?
+              
+              # If it's a timeout (exit code 124), check if publish actually succeeded
+              if [ $EXIT_CODE -eq 124 ]; then
+                echo "Publish attempt timed out. Checking if version was actually published..."
+                
+                # Check if the version exists in ClawHub
+                if clawhub inspect social-ops --json | jq -r '.versions[].tag' | grep -q "^${VERSION}$"; then
+                  echo "Version ${VERSION} confirmed published despite timeout. Exiting successfully."
+                  exit 0
+                else
+                  echo "Version ${VERSION} not found. Publish likely failed."
+                fi
+              else
+                echo "Publish failed with exit code ${EXIT_CODE}"
+              fi
             fi
 
             if [ "$attempt" -lt "$ATTEMPTS" ]; then
@@ -51,4 +70,13 @@ jobs:
           done
 
           echo "ClawHub publish failed after ${ATTEMPTS} attempts"
-          exit 1
+          
+          # Final check: if all attempts failed, do one last verification
+          echo "Final verification: checking if version was published despite failures..."
+          if clawhub inspect social-ops --json | jq -r '.versions[].tag' | grep -q "^${VERSION}$"; then
+            echo "Version ${VERSION} confirmed published. Exiting successfully."
+            exit 0
+          else
+            echo "Version ${VERSION} not found. Publish failed."
+            exit 1
+          fi


### PR DESCRIPTION
Summary:\nThis PR enhances the ClawHub publish workflow to be more tolerant of timeout errors while ensuring the package is still published correctly.\n\nFiles Changed:\n- .github/workflows/clawhub-publish.yml\n\nWhy:\nThe previous implementation only added retries but didn't handle the case where a timeout occurs but the package is still successfully published.\n\nTesting/Validation:\n- Reviewed workflow syntax and logic flow\n- Confirmed jq parsing and version matching logic is correct\n- Verified backward compatibility\n\nNext Step:\nMerge this PR to complete issue #22 resolution.