### PR TITLE
Add OpenClaw cron installer + baseline cron setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ Built for OpenClaw agents.
 For deterministic implementation passes, use `references/tasks/QUEUE.md`
 with the task format in `references/tasks/TEMPLATE.md`.
 
+## Cron Job Setup
+
+For setting up automated execution of social-media roles, see [references/crons/InstallCrons.md](references/crons/InstallCrons.md).
+
+Quick start:
+```bash
+./scripts/install-cron-jobs.sh
+```
+
 ## Path Conventions
 
 For `{baseDir}` and workspace-relative path rules, see:

--- a/SKILL.md
+++ b/SKILL.md
@@ -80,3 +80,11 @@ assets/               Imported strategy artifacts and static source material
   strategy/           North-star strategy documents
 scripts/              Optional helper scripts and adapters
 ```
+
+## Cron Job Creation Prompt
+
+For setting up automated execution of social-media roles, see [references/crons/InstallCrons.md](references/crons/InstallCrons.md).
+
+Use one of these paths:
+- **Basic install:** run `./scripts/install-cron-jobs.sh` from this repo root.
+- **Custom install/tuning:** use `scripts/install-cron-jobs.sh` and `references/crons/InstallCrons.md` as templates, preserving `{baseDir}` conventions and role boundaries.

--- a/references/crons/InstallCrons.md
+++ b/references/crons/InstallCrons.md
@@ -1,0 +1,64 @@
+# Social Ops OpenClaw Cron Baseline
+
+This guide defines the baseline social-media cron set and how to install it with OpenClaw.
+
+## Quick Install (recommended)
+
+Run the installer script from the repository root:
+
+```bash
+./scripts/install-cron-jobs.sh
+```
+
+Optional flags:
+
+```bash
+# Preview commands only
+./scripts/install-cron-jobs.sh --dry-run
+
+# Customize skill path + timezone
+./scripts/install-cron-jobs.sh \
+  --base-dir /path/to/openclaw-skill-social-ops \
+  --tz America/New_York
+```
+
+The script **upserts** all six jobs:
+- creates missing jobs with `openclaw cron add`
+- updates existing jobs with `openclaw cron edit`
+
+## Portable Prompt Template (for custom installs)
+
+Use this prompt when you want to hand-craft your own schedule while preserving role boundaries:
+
+> Create (or update) OpenClaw cron jobs for this skill using `{baseDir}` path conventions.
+> 
+> Use these jobs (session target: `isolated`, timezone: `America/New_York`):
+> - `Moltbook Poster` — `0 9,13,17,21 * * *`
+> - `Moltbook Responder` — `15 8,11,14,17,20,23 * * *`
+> - `Moltbook Scout` — `30 8,19 * * *`
+> - `Moltbook Content Specialist` — `0 1 * * *`
+> - `Moltbook Researcher` — `0 2 * * 2,5`
+> - `Moltbook Analyst` — `0 19 * * 0`
+> 
+> Primary 
+> Instruct the agent that they're to use the social-ops skill, and they're acting in a role, and set their role.
+> Instruct the agent to use the moltbook skill to complete operations as required by the social-ops skill
+> 
+> Preserve role constraints, or customize to user instructions:
+> - Poster: post max one item/run; clean exit + log if Todo empty.
+> - Responder: meaningful replies only; 1–3 sentences; max one Scout insertion.
+> - Scout: opportunities only; max 3 opportunities/run; no engagement actions.
+> - Content Specialist: lane clarity + backlog drafting only.
+> - Researcher: 1–3 research tasks + up to 0–2 follow-ups.
+> - Analyst: weekly pattern analysis only; avoid overfitting to single-post spikes.
+> 
+> Use `openclaw cron add` for new jobs and `openclaw cron edit` for existing jobs.
+
+## Cadence Tuning Notes
+
+You can tune schedule expressions without breaking architecture. Keep role boundaries intact:
+
+- Increase/decrease run frequency by editing cron expressions only.
+- Do not merge role responsibilities to "save runs".
+- Keep Analyst at least weekly.
+- Keep Poster capped at one post per run.

--- a/scripts/install-cron-jobs.sh
+++ b/scripts/install-cron-jobs.sh
@@ -1,0 +1,253 @@
+#!/usr/bin/env bash
+
+# Install or update the baseline social-ops OpenClaw cron jobs.
+# Usage:
+#   ./scripts/install-cron-jobs.sh
+#   ./scripts/install-cron-jobs.sh --base-dir /path/to/skill --tz America/Los_Angeles
+#
+# This script UPSERTs jobs by name:
+# - If a job exists, it is updated via `openclaw cron edit`
+# - If it does not exist, it is created via `openclaw cron add`
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_BASE_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BASE_DIR="${DEFAULT_BASE_DIR}"
+TZ_NAME="America/New_York"
+DRY_RUN="false"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base-dir)
+      BASE_DIR="$2"
+      shift 2
+      ;;
+    --tz)
+      TZ_NAME="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN="true"
+      shift
+      ;;
+    -h|--help)
+      sed -n '1,20p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! command -v openclaw >/dev/null 2>&1; then
+  echo "openclaw CLI not found in PATH." >&2
+  exit 1
+fi
+
+run_cmd() {
+  if [[ "${DRY_RUN}" == "true" ]]; then
+    echo "+ $*"
+  else
+    "$@"
+  fi
+}
+
+get_existing_job_id() {
+  local job_name="$1"
+
+  openclaw cron list --all --json 2>/dev/null | python3 - "$job_name" <<'PY'
+import json
+import sys
+
+needle = sys.argv[1]
+raw = sys.stdin.read().strip()
+if not raw:
+    print("")
+    raise SystemExit(0)
+
+try:
+    data = json.loads(raw)
+except Exception:
+    print("")
+    raise SystemExit(0)
+
+jobs = []
+if isinstance(data, list):
+    jobs = data
+elif isinstance(data, dict):
+    if isinstance(data.get("jobs"), list):
+        jobs = data["jobs"]
+    elif isinstance(data.get("items"), list):
+        jobs = data["items"]
+
+for j in jobs:
+    if isinstance(j, dict) and j.get("name") == needle:
+        print(j.get("id", ""))
+        raise SystemExit(0)
+
+print("")
+PY
+}
+
+upsert_job() {
+  local name="$1"
+  local cron_expr="$2"
+  local description="$3"
+  local message="$4"
+
+  local existing_id
+  existing_id="$(get_existing_job_id "$name")"
+
+  if [[ -n "${existing_id}" ]]; then
+    echo "Updating existing job: ${name} (${existing_id})"
+    run_cmd openclaw cron edit "${existing_id}" \
+      --name "${name}" \
+      --description "${description}" \
+      --cron "${cron_expr}" \
+      --tz "${TZ_NAME}" \
+      --session isolated \
+      --message "${message}" \
+      --enable
+  else
+    echo "Creating new job: ${name}"
+    run_cmd openclaw cron add \
+      --name "${name}" \
+      --description "${description}" \
+      --cron "${cron_expr}" \
+      --tz "${TZ_NAME}" \
+      --session isolated \
+      --message "${message}"
+  fi
+}
+
+poster_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+
+Run Role: Poster
+
+
+Constraints:
+- Execute Poster scope only.
+- Post at most ONE item per run.
+- If Todo is empty: clean exit and log.
+- No cross-role work.
+- No private context leakage.
+- Use credentials file auth and complete verification challenge if pending.
+EOF
+)
+
+responder_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+Run Role: Responder
+
+Constraints:
+- Reply/DM hygiene only; meaningful engagement.
+- 1-3 sentence replies.
+- Max one Scout-sourced insertion.
+- If nothing new: quiet pass and log.
+- No cross-role work.
+- No private context leakage.
+- Use credentials file auth and complete verification challenge if pending.
+EOF
+)
+
+scout_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+Run Role: Scout
+
+Constraints:
+- Detect opportunities only (no posting/replying/upvoting).
+- Max 3 opportunities per run with routing suggestions.
+- Avoid duplicate opportunities.
+- No private context leakage.
+- Use credentials file auth and complete verification challenge if pending.
+EOF
+)
+
+content_specialist_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+Run Role: Content Specialist
+
+Constraints:
+- Lane clarity + backlog draft generation only.
+- No posting, replying, or analytics.
+- Keep identity/tone aligned.
+- No private context leakage.
+EOF
+)
+
+researcher_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+Run Role: Researcher
+
+Constraints:
+- Complete 1-3 research tasks.
+- Add max 0-2 follow-up tasks.
+- Evidence-backed guidance only.
+- No posting/replying/upvoting/backlog edits.
+- Use credentials file auth and complete verification challenge if pending.
+EOF
+)
+
+analyst_msg=$(cat <<EOF
+You are executing on a social media plan.
+
+You will use the moltbook skill.
+Use social-ops skill now, and figure out what instructions are necessary for your role.
+
+You will adhere to your role, and read the files as instructed.
+Run Role: Analyst
+
+Constraints:
+- Weekly pattern analysis only.
+- Use logs + done posts + metrics for recommendations.
+- No posting/replying/lane edits.
+- Avoid overfitting to one-post spikes.
+- Use credentials file auth and complete verification challenge if pending.
+EOF
+)
+
+echo "Installing social-ops baseline cron jobs"
+echo "Base dir: ${BASE_DIR}"
+echo "Timezone: ${TZ_NAME}"
+
+upsert_job "Moltbook Poster" "0 9,13,17,21 * * *" "Poster role baseline run" "${poster_msg}"
+upsert_job "Moltbook Responder" "15 8,11,14,17,20,23 * * *" "Responder role baseline run" "${responder_msg}"
+upsert_job "Moltbook Scout" "30 8,19 * * *" "Scout role baseline run" "${scout_msg}"
+upsert_job "Moltbook Content Specialist" "0 1 * * *" "Content Specialist role baseline run" "${content_specialist_msg}"
+upsert_job "Moltbook Researcher" "0 2 * * 2,5" "Researcher role baseline run" "${researcher_msg}"
+upsert_job "Moltbook Analyst" "0 19 * * 0" "Analyst role baseline run" "${analyst_msg}"
+
+echo "Done."
+if [[ "${DRY_RUN}" == "true" ]]; then
+  echo "(dry-run only; no changes were applied)"
+fi


### PR DESCRIPTION
## Summary
- add `scripts/install-cron-jobs.sh` to create/update the six baseline social-ops cron jobs via `openclaw cron add|edit`
- add canonical baseline cron prompt/install guide at `references/crons/InstallCrons.md`
- update `SKILL.md` to recommend running the installer script for basic setup or using it as a customization reference
- update cron setup doc references to use the new canonical guide

## Notes
- keeps path usage aligned to `{baseDir}` conventions
- leaves role boundaries intact while allowing cadence tuning

Closes #27
