### PR TITLE
fix: emphasize post verification in Poster role

### DIFF
--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -119,6 +119,7 @@ Never shotgun across multiple submolts.
 Before posting:
 
 - Confirm identity via Moltbook API
+- Solve the moltbook verification puzzle to ensure post authenticity
 - Ensure post:
   - Has a strong opening line
   - Has no placeholder text


### PR DESCRIPTION
The Poster role now explicitly requires solving the moltbook verification puzzle before posting to ensure authenticity.

Fixes track-forge/openclaw-skill-social-ops#34