### PR TITLE
Content Specialist: add local file references input + remove Reddit artifacts

### DIFF
--- a/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
+++ b/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
@@ -1,0 +1,39 @@
+# Local File References (Template)
+
+Use this template to create:
+
+`{baseDir}/Social/Guidance/Local-File-References.md`
+
+Purpose:
+- Provide a human-editable list of local files/directories that the **Content Specialist** may read during backlog generation.
+- Keep source selection explicit and auditable.
+
+## Rules
+
+- Keep paths relative to the skill runtime root where possible.
+- Prefer small, high-signal files over huge directories.
+- Mark optional items clearly.
+- Remove stale paths instead of letting the list rot.
+
+## Suggested format
+
+```markdown
+# Local File References
+
+## Required
+- Projects/Some-Project.md
+- Creative/Ideas/Recurring-Themes.md
+
+## Optional
+- Reference/Bolton/
+- Notes/Experiments/
+
+## Exclusions
+- Private/
+- Archive/
+```
+
+## Notes for operators
+
+- Missing paths are non-fatal; the run should continue.
+- The Content Specialist should log skipped/missing references in its daily content log.

--- a/references/ROLE-IO-MAP.md
+++ b/references/ROLE-IO-MAP.md
@@ -56,13 +56,12 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Content Specialist
 - Reads:
   - `{baseDir}/Social/Guidance/README.md`
+  - `{baseDir}/Social/Guidance/Local-File-References.md` (optional, human-curated)
   - `{baseDir}/Social/Content/Lanes/`
-  - `Projects/`
-  - `Creative/`
-  - `Reference/Reddit/`
   - recent `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
   - `{baseDir}/Social/Submolts/Candidates.md`
   - `{baseDir}/Social/Submolts/Primary.md`
+  - local files/directories referenced by `Local-File-References.md` (only if present/accessible)
 - Writes:
   - `{baseDir}/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
   - `{baseDir}/Social/Content/Lanes/*.md` (create/refine/retire lane definitions)
@@ -119,6 +118,7 @@ Analyst recommendations ──> Content Specialist + Researcher
 - Guidance artifacts:
   - `{baseDir}/Social/Guidance/README.md` (producer: Researcher; consumers: Content Specialist, Poster, Analyst)
   - `{baseDir}/Social/Guidance/Research-Tasks.md` (producer/consumer: Researcher)
+  - `{baseDir}/Social/Guidance/Local-File-References.md` (producer: human operator and/or Researcher; consumer: Content Specialist)
 
 - Pipeline artifacts:
   - `{baseDir}/Social/Content/Todo/` (producer: Content Specialist; consumer: Poster)

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -37,12 +37,16 @@ The Content Specialist must review:
 1. `{baseDir}/Social/Guidance/README.md`
 2. `{baseDir}/Social/Content/Lanes/`
 3. `{baseDir}/Social/Submolts/Primary.md`
-4. `Projects/`
-5. `Creative/`
-6. `Reference/Reddit/`
-7. Recent Research logs
+4. Recent Research logs
 
 Before generating new posts.
+
+Optional local content references (human-configurable):
+
+- If present, read `{baseDir}/Social/Guidance/Local-File-References.md`.
+- Treat it as a curated list of local files/directories that may inform content generation.
+- Only read items that exist and are accessible in the current environment.
+- Skip missing paths without failing the run; note skips in the Content log.
 
 ---
 
@@ -103,10 +107,11 @@ On each run:
 
 - Read Guidance README
 - Scan active lanes
-- Scan Projects (respect private markers)
-- Scan Creative directory
-- Review Reddit reference corpus
 - Review recent Research logs
+- If `{baseDir}/Social/Guidance/Local-File-References.md` exists:
+  - Read listed local references (files/directories) that exist.
+  - Use them as optional context inputs for content generation.
+  - Record any missing/unreadable configured references in the run log.
 
 ### Step 2 — Adjust Lanes if Needed
 
@@ -189,9 +194,9 @@ Body:
 New lane ideas may come from:
 
 * High-performing patterns in Research guidance
-* Recurring Reddit themes from `Reference/Reddit/`
-* Emerging Projects
-* Strong Creative concepts appearing repeatedly
+* Recurring themes from configured local references in `{baseDir}/Social/Guidance/Local-File-References.md`
+* Emerging projects/artifacts from local references
+* Strong creative concepts appearing repeatedly
 
 A lane should only be created if:
 


### PR DESCRIPTION
Closes #42.

## What changed
- Updated `references/roles/Content-Specialist.md` to support a human-configurable local input list via:
  - `{baseDir}/Social/Guidance/Local-File-References.md` (optional)
- Removed Reddit-specific references from Content Specialist behavior.
- Added conditional-read behavior:
  - only read listed local paths when present/accessible
  - skip missing paths without failing the run
  - log skipped references in content logs
- Updated `references/ROLE-IO-MAP.md` to reflect the new local reference input artifact and consumption flow.
- Added `references/LOCAL-FILE-REFERENCES-TEMPLATE.md` to standardize operator customization.

## Why
Issue #42 requested lane/content generation improvements so Content Specialist can consume a curated list of local files, and asked to remove old Reddit-specific artifacts.

## Role/subsystem impact
- Affected role: **Content Specialist**
- Affected handoff map: **ROLE-IO-MAP**
- No platform lock-in added; this remains local-file and path-policy oriented.

## Feedback loop implications
- Human/operator and Researcher can now curate `Local-File-References.md` as a durable input surface.
- Content Specialist uses this list to ground lane/backlog drafting with optional, explicit local context.
- This creates a cleaner, auditable guidance -> content pipeline without hardcoded source assumptions.

## Validation
- Verified `references/roles/Content-Specialist.md` contains no Reddit references.
- Confirmed docs update includes the new artifact in ROLE-IO map and shared artifact section.
