### PR TITLE
fix(paths): move Social runtime data to <workspace>/Social

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,13 @@ your-skill/
 So when making prompts use things such as:
 
 ```
-Open the file found in {baseDir}/Social/roles/
+Open the file found in <workspace>/Social/roles/
 ```
 
 or
 
 ```
-Look for recent files in {baseDir}/Social/Content
+Look for recent files in <workspace>/Social/Content
 ```
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -65,7 +65,7 @@ Role-to-role artifact flow and logging ownership are documented in:
 Use these path rules to keep the skill portable:
 
 - Skill-owned files (docs, scripts, assets): use `{baseDir}/...`
-- Runtime/social data files (logs, guidance, todo/done queues): keep them under `{baseDir}/Social/...`.
+- Runtime/social data files (logs, guidance, todo/done queues): keep them under `<workspace>/Social/...`.
 - Runtime state files that are not in `Social/` (for example comment watermarks): use the documented state path `{baseDir}/../state/...` until state-location policy changes.
 
 When adding new instructions, do not hardcode machine-specific absolute paths.

--- a/docs/PATH-CONVENTIONS.md
+++ b/docs/PATH-CONVENTIONS.md
@@ -24,19 +24,19 @@ Examples:
 
 Use these locations for role runtime artifacts generated during operation:
 
-- Social skill data lives inside the skill base directory:
-  - `{baseDir}/Social/Guidance/**`
-  - `{baseDir}/Social/Content/Todo/**`
-  - `{baseDir}/Social/Content/Done/**`
-  - `{baseDir}/Social/Content/Logs/**`
+- Social runtime data lives in the workspace (outside the installed skill directory):
+  - `<workspace>/Social/Guidance/**`
+  - `<workspace>/Social/Content/Todo/**`
+  - `<workspace>/Social/Content/Done/**`
+  - `<workspace>/Social/Content/Logs/**`
 - Comment watermark state remains at:
   - `{baseDir}/../state/comment-state.json`
 
-`Social/` is intentionally kept inside `{baseDir}` for this skill.
+`Social/` is intentionally workspace-scoped to avoid data loss during skill updates.
 
 ## Rule for future edits
 
 - Do not introduce absolute host paths.
 - For packaged skill references, prefer `{baseDir}`.
-- For generated Social runtime artifacts, keep paths under `{baseDir}/Social/...`.
+- For generated Social runtime artifacts, keep paths under `<workspace>/Social/...`.
 - For known state artifacts, use the documented state path until policy changes.

--- a/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
+++ b/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Use this template to create:
 
-`{baseDir}/Social/Guidance/Local-File-References.md`
+`<workspace>/Social/Guidance/Local-File-References.md`
 
 Purpose:
 - Provide a human-editable list of local files/directories that the **Content Specialist** may read during backlog generation.

--- a/references/ROLE-IO-MAP.md
+++ b/references/ROLE-IO-MAP.md
@@ -24,13 +24,13 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Scout
 - Reads:
   - Moltbook feed/submolts/accounts (platform data)
-  - `{baseDir}/Social/Guidance/README.md`
-  - `{baseDir}/Social/Content/Lanes/`
-  - `{baseDir}/Social/Submolts/Primary.md`
-  - `{baseDir}/Social/Submolts/Candidates.md`
+  - `<workspace>/Social/Guidance/README.md`
+  - `<workspace>/Social/Content/Lanes/`
+  - `<workspace>/Social/Submolts/Primary.md`
+  - `<workspace>/Social/Submolts/Candidates.md`
 - Writes:
-  - `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Submolts/Candidates.md` (new candidate entries)
+  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+  - `<workspace>/Social/Submolts/Candidates.md` (new candidate entries)
 - Primary consumers:
   - Responder (thread insertion opportunities)
   - Content Specialist (topic opportunities)
@@ -39,15 +39,15 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Researcher
 - Reads:
   - Moltbook high-performing posts/accounts
-  - `{baseDir}/Social/Guidance/Research-Tasks.md` (task queue)
+  - `<workspace>/Social/Guidance/Research-Tasks.md` (task queue)
   - prior research logs
-  - `{baseDir}/Social/Submolts/Candidates.md`
-  - `{baseDir}/Social/Submolts/Primary.md`
+  - `<workspace>/Social/Submolts/Candidates.md`
+  - `<workspace>/Social/Submolts/Primary.md`
 - Writes:
-  - `{baseDir}/Social/Guidance/README.md` (durable guidance)
-  - `{baseDir}/Social/Guidance/Research-Tasks.md` (task queue updates)
-  - `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Submolts/Candidates.md` (analysis notes, additional candidates)
+  - `<workspace>/Social/Guidance/README.md` (durable guidance)
+  - `<workspace>/Social/Guidance/Research-Tasks.md` (task queue updates)
+  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+  - `<workspace>/Social/Submolts/Candidates.md` (analysis notes, additional candidates)
 - Primary consumers:
   - Content Specialist (content planning)
   - Poster (tone/check alignment)
@@ -55,50 +55,50 @@ Analyst recommendations ──> Content Specialist + Researcher
 
 ## Content Specialist
 - Reads:
-  - `{baseDir}/Social/Guidance/README.md`
-  - `{baseDir}/Social/Guidance/Local-File-References.md` (optional, human-curated)
-  - `{baseDir}/Social/Content/Lanes/`
-  - recent `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Submolts/Candidates.md`
-  - `{baseDir}/Social/Submolts/Primary.md`
+  - `<workspace>/Social/Guidance/README.md`
+  - `<workspace>/Social/Guidance/Local-File-References.md` (optional, human-curated)
+  - `<workspace>/Social/Content/Lanes/`
+  - recent `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+  - `<workspace>/Social/Submolts/Candidates.md`
+  - `<workspace>/Social/Submolts/Primary.md`
   - local files/directories referenced by `Local-File-References.md` (only if present/accessible)
 - Writes:
-  - `{baseDir}/Social/Content/Lanes/*.md` (create/refine/retire lane definitions)
-  - `{baseDir}/Social/Content/Logs/Content-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Submolts/Primary.md` (promotions from Candidates)
-  - `{baseDir}/Social/Submolts/Candidates.md` (removals after promotion)
-  - `{baseDir}/Social/Submolts/Retired.md` (retired submolts)
+  - `<workspace>/Social/Content/Lanes/*.md` (create/refine/retire lane definitions)
+  - `<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md`
+  - `<workspace>/Social/Submolts/Primary.md` (promotions from Candidates)
+  - `<workspace>/Social/Submolts/Candidates.md` (removals after promotion)
+  - `<workspace>/Social/Submolts/Retired.md` (retired submolts)
 - Primary consumers:
   - Writer (drafts posts based on lanes)
   - Analyst (evaluates lane/post pipeline performance)
 
 ## Writer
 - Reads:
-  - `{baseDir}/Social/Content/Memory/writer.md` (long-term memory)
-  - `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md` (last 3 days)
-  - `{baseDir}/Social/Content/Lanes/` (selects one lane per run)
-  - `{baseDir}/Social/Content/Todo/` (queue depth check)
-  - `{baseDir}/Social/Submolts/Primary.md`
-  - `{baseDir}/Social/Guidance/Local-File-References.md` (optional, human-curated)
+  - `<workspace>/Social/Content/Memory/writer.md` (long-term memory)
+  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (last 3 days)
+  - `<workspace>/Social/Content/Lanes/` (selects one lane per run)
+  - `<workspace>/Social/Content/Todo/` (queue depth check)
+  - `<workspace>/Social/Submolts/Primary.md`
+  - `<workspace>/Social/Guidance/Local-File-References.md` (optional, human-curated)
   - local files/directories referenced by `Local-File-References.md` (only if present/accessible)
-  - recent `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
+  - recent `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
 - Writes:
-  - `{baseDir}/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
-  - `{baseDir}/Social/Content/Memory/writer.md` (long-term memory updates)
-  - `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md` (daily memory log)
-  - `{baseDir}/Social/Content/Logs/Writer-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
+  - `<workspace>/Social/Content/Memory/writer.md` (long-term memory updates)
+  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (daily memory log)
+  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
 - Primary consumers:
   - Poster (publishes TODO items)
   - Analyst (evaluates post quality and queue balance)
 
 ## Poster
 - Reads:
-  - `{baseDir}/Social/Guidance/README.md`
-  - `{baseDir}/Social/Content/Todo/`
-  - `{baseDir}/Social/Content/Lanes/`
+  - `<workspace>/Social/Guidance/README.md`
+  - `<workspace>/Social/Content/Todo/`
+  - `<workspace>/Social/Content/Lanes/`
 - Writes:
-  - `{baseDir}/Social/Content/Done/` (moves posted file from Todo)
-  - `{baseDir}/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Done/` (moves posted file from Todo)
+  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
   - published post URL attached to moved post artifact
 - Primary consumers:
   - Analyst (performance review)
@@ -108,25 +108,25 @@ Analyst recommendations ──> Content Specialist + Researcher
 - Reads:
   - Moltbook replies/DMs/mentions
   - `{baseDir}/../state/comment-state.json`
-  - latest Scout log: `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+  - latest Scout log: `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
 - Writes:
   - `{baseDir}/../state/comment-state.json` (watermarks + seen ids)
-  - `{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
 - Primary consumers:
   - Analyst (relational signal quality)
 
 ## Analyst
 - Reads:
-  - `{baseDir}/Social/Content/Done/`
-  - `{baseDir}/Social/Content/Logs/Poster-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Content/Logs/Writer-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `{baseDir}/Social/Submolts/Primary.md`
+  - `<workspace>/Social/Content/Done/`
+  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+  - `<workspace>/Social/Submolts/Primary.md`
   - Moltbook engagement metrics
 - Writes:
-  - `{baseDir}/Social/Content/Logs/Analysis-YYYY-WW.md` (includes submolt retirement recommendations)
+  - `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md` (includes submolt retirement recommendations)
   - recommendations (consumed by Content Specialist + Researcher)
 - Primary consumers:
   - Content Specialist (lane/cadence changes)
@@ -135,32 +135,32 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Shared artifact map
 
 - Guidance artifacts:
-  - `{baseDir}/Social/Guidance/README.md` (producer: Researcher; consumers: Content Specialist, Poster, Analyst)
-  - `{baseDir}/Social/Guidance/Research-Tasks.md` (producer/consumer: Researcher)
-  - `{baseDir}/Social/Guidance/Local-File-References.md` (producer: human operator and/or Researcher; consumers: Content Specialist, Writer)
+  - `<workspace>/Social/Guidance/README.md` (producer: Researcher; consumers: Content Specialist, Poster, Analyst)
+  - `<workspace>/Social/Guidance/Research-Tasks.md` (producer/consumer: Researcher)
+  - `<workspace>/Social/Guidance/Local-File-References.md` (producer: human operator and/or Researcher; consumers: Content Specialist, Writer)
 
 - Pipeline artifacts:
-  - `{baseDir}/Social/Content/Todo/` (producer: Writer; consumer: Poster)
-  - `{baseDir}/Social/Content/Done/` (producer: Poster; consumer: Analyst)
-  - `{baseDir}/Social/Content/Lanes/` (producer: Content Specialist; consumers: Poster, Analyst)
+  - `<workspace>/Social/Content/Todo/` (producer: Writer; consumer: Poster)
+  - `<workspace>/Social/Content/Done/` (producer: Poster; consumer: Analyst)
+  - `<workspace>/Social/Content/Lanes/` (producer: Content Specialist; consumers: Poster, Analyst)
 
 - Log artifacts:
-  - `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md` (producer: Scout; consumers: Responder, Analyst)
-  - `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md` (producer: Researcher; consumers: Content Specialist, Analyst)
-  - `{baseDir}/Social/Content/Logs/Content-YYYY-MM-DD.md` (producer: Content Specialist; consumer: Analyst)
-  - `{baseDir}/Social/Content/Logs/Writer-YYYY-MM-DD.md` (producer: Writer; consumer: Analyst)
-  - `{baseDir}/Social/Content/Logs/Poster-YYYY-MM-DD.md` (producer: Poster; consumer: Analyst)
-  - `{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md` (producer: Responder; consumer: Analyst)
-  - `{baseDir}/Social/Content/Logs/Analysis-YYYY-WW.md` (producer: Analyst; consumers: Content Specialist, Researcher)
+  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md` (producer: Scout; consumers: Responder, Analyst)
+  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md` (producer: Researcher; consumers: Content Specialist, Analyst)
+  - `<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md` (producer: Content Specialist; consumer: Analyst)
+  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md` (producer: Writer; consumer: Analyst)
+  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md` (producer: Poster; consumer: Analyst)
+  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md` (producer: Responder; consumer: Analyst)
+  - `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md` (producer: Analyst; consumers: Content Specialist, Researcher)
 
 - Submolt lifecycle artifacts:
-  - `{baseDir}/Social/Submolts/Primary.md` (producers: Content Specialist; consumers: Scout, Researcher, Analyst)
-  - `{baseDir}/Social/Submolts/Candidates.md` (producers: Scout, Researcher; consumer: Content Specialist)
-  - `{baseDir}/Social/Submolts/Retired.md` (producer: Content Specialist; consumer: Analyst)
+  - `<workspace>/Social/Submolts/Primary.md` (producers: Content Specialist; consumers: Scout, Researcher, Analyst)
+  - `<workspace>/Social/Submolts/Candidates.md` (producers: Scout, Researcher; consumer: Content Specialist)
+  - `<workspace>/Social/Submolts/Retired.md` (producer: Content Specialist; consumer: Analyst)
 
 - Memory artifacts:
-  - `{baseDir}/Social/Content/Memory/writer.md` (producer/consumer: Writer; long-term creative memory)
-  - `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md` (producer: Writer; consumer: Writer on subsequent runs)
+  - `<workspace>/Social/Content/Memory/writer.md` (producer/consumer: Writer; long-term creative memory)
+  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (producer: Writer; consumer: Writer on subsequent runs)
 
 - Runtime state artifacts:
   - `{baseDir}/../state/comment-state.json` (producer/consumer: Responder)

--- a/references/roles/Analyst.md
+++ b/references/roles/Analyst.md
@@ -34,15 +34,15 @@ It does not run daily.
 ## 3. Inputs
 
 Social workspace root:
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 Primary data sources:
 
-- `{baseDir}/Social/Content/Done/`
-- `{baseDir}/Social/Content/Logs/Poster-YYYY-MM-DD.md`
-- `{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md`
-- `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-- `{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
+- `<workspace>/Social/Content/Done/`
+- `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+- `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+- `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+- `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
 - Moltbook engagement metrics (via API)
 
 Metrics to gather:
@@ -97,7 +97,7 @@ For posts in `Done/`:
 
 Analyst writes to:
 
-`{baseDir}/Social/Content/Logs/Analysis-YYYY-WW.md`
+`<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md`
 
 Weekly format example:
 
@@ -200,8 +200,8 @@ Analyst must review engagement by submolt during each analysis run.
 
 Inputs:
 
-- `{baseDir}/Social/Submolts/Primary.md`
-- `{baseDir}/Social/Content/Done/`
+- `<workspace>/Social/Submolts/Primary.md`
+- `<workspace>/Social/Content/Done/`
 
 Recommend retirement if:
 
@@ -212,5 +212,5 @@ Recommend retirement if:
 **Constraints:**
 
 - Analyst does not directly move submolts.
-- Analyst only recommends — writes recommendations to `{baseDir}/Social/Content/Logs/Analysis-YYYY-WW.md`.
+- Analyst only recommends — writes recommendations to `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md`.
 - Content Specialist acts on retirement recommendations.

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -31,20 +31,20 @@ It shapes the strategy. The Writer executes it.
 ## 2. Primary Inputs
 
 Social workspace root:
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 The Content Specialist must review:
 
-1. `{baseDir}/Social/Guidance/README.md`
-2. `{baseDir}/Social/Content/Lanes/`
-3. `{baseDir}/Social/Submolts/Primary.md`
+1. `<workspace>/Social/Guidance/README.md`
+2. `<workspace>/Social/Content/Lanes/`
+3. `<workspace>/Social/Submolts/Primary.md`
 4. Recent Research logs
 
 Before adjusting lanes or guidance.
 
 Optional local content references (human-configurable):
 
-- If present, read `{baseDir}/Social/Guidance/Local-File-References.md`.
+- If present, read `<workspace>/Social/Guidance/Local-File-References.md`.
 - Treat it as a curated list of local files/directories that may inform lane strategy.
 - Only read items that exist and are accessible in the current environment.
 - Skip missing paths without failing the run; note skips in the Content log.
@@ -55,7 +55,7 @@ Optional local content references (human-configurable):
 
 Lane files live in:
 
-`{baseDir}/Social/Content/Lanes/`
+`<workspace>/Social/Content/Lanes/`
 
 Each lane file should define:
 
@@ -109,7 +109,7 @@ On each run:
 - Read Guidance README
 - Scan active lanes
 - Review recent Research logs
-- If `{baseDir}/Social/Guidance/Local-File-References.md` exists:
+- If `<workspace>/Social/Guidance/Local-File-References.md` exists:
   - Read listed local references (files/directories) that exist.
   - Use them as optional context inputs for lane strategy decisions.
   - Record any missing/unreadable configured references in the run log.
@@ -126,7 +126,7 @@ After lane adjustments, verify that:
 
 - Active lanes have clear definitions the Writer can act on
 - Lane frequency targets are up to date
-- `{baseDir}/Social/Submolts/Primary.md` is current (for Writer submolt targeting)
+- `<workspace>/Social/Submolts/Primary.md` is current (for Writer submolt targeting)
 
 The Content Specialist does not generate posts — the Writer handles post drafting based on the lanes and guidance the Content Specialist maintains.
 
@@ -137,7 +137,7 @@ The Content Specialist does not generate posts — the Writer handles post draft
 New lane ideas may come from:
 
 * High-performing patterns in Research guidance
-* Recurring themes from configured local references in `{baseDir}/Social/Guidance/Local-File-References.md`
+* Recurring themes from configured local references in `<workspace>/Social/Guidance/Local-File-References.md`
 * Emerging projects/artifacts from local references
 * Strong creative concepts appearing repeatedly
 
@@ -167,7 +167,7 @@ It shapes the pipeline. The Writer fills it.
 
 Each run appends to:
 
-`{baseDir}/Social/Content/Logs/Content-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md`
 
 Log format:
 
@@ -219,7 +219,7 @@ The Content Specialist owns submolt lifecycle transitions.
 
 ### Regular Tasks
 
-- Ensure the agent is subscribed to all submolts listed in `{baseDir}/Social/Submolts/Primary.md`.
+- Ensure the agent is subscribed to all submolts listed in `<workspace>/Social/Submolts/Primary.md`.
 - Mark checkboxes for subscribed submolts in Primary.md.
 
 ### Promotion (Candidates → Primary)
@@ -229,21 +229,21 @@ Rules:
 - May promote up to **2 submolts per day** from Candidates → Primary.
 - Must base decision on:
   - Researcher notes in Candidates.md
-  - Guidance alignment (`{baseDir}/Social/Guidance/README.md`)
-  - Lane relevance (`{baseDir}/Social/Content/Lanes/`)
+  - Guidance alignment (`<workspace>/Social/Guidance/README.md`)
+  - Lane relevance (`<workspace>/Social/Content/Lanes/`)
 
 Steps:
 
-1. Move the entry from `{baseDir}/Social/Submolts/Candidates.md`
-2. Add to `{baseDir}/Social/Submolts/Primary.md`
+1. Move the entry from `<workspace>/Social/Submolts/Candidates.md`
+2. Add to `<workspace>/Social/Submolts/Primary.md`
 3. Remove from Candidates.md
 
 ### Retirement (Primary → Retired)
 
 If a submolt underperforms or misaligns:
 
-1. Move from `{baseDir}/Social/Submolts/Primary.md`
-2. Append to `{baseDir}/Social/Submolts/Retired.md`
+1. Move from `<workspace>/Social/Submolts/Primary.md`
+2. Append to `<workspace>/Social/Submolts/Retired.md`
 
 Format in Retired.md:
 

--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -11,13 +11,13 @@ The Poster executes.
 
 It takes finished post drafts from:
 
-`{baseDir}/Social/Content/Todo/`
+`<workspace>/Social/Content/Todo/`
 
 Publishes them to Moltbook.
 
 Moves them to:
 
-`{baseDir}/Social/Content/Done/`
+`<workspace>/Social/Content/Done/`
 
 It does not ideate.
 It does not research.
@@ -32,13 +32,13 @@ It publishes with confidence.
 
 Social workspace root:
 
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 Primary inputs:
 
-- `{baseDir}/Social/Guidance/README.md`
-- `{baseDir}/Social/Content/Todo/`
-- Lane definitions in `{baseDir}/Social/Content/Lanes/`
+- `<workspace>/Social/Guidance/README.md`
+- `<workspace>/Social/Content/Todo/`
+- Lane definitions in `<workspace>/Social/Content/Lanes/`
 
 Moltbook interactions must use documented Moltbook skill patterns.
 
@@ -66,7 +66,7 @@ Consistency > burst posting.
 
 Briefly review:
 
-`{baseDir}/Social/Guidance/README.md`
+`<workspace>/Social/Guidance/README.md`
 
 This ensures:
 - Tone alignment
@@ -82,7 +82,7 @@ Just align tone and structure.
 
 Scan:
 
-`{baseDir}/Social/Content/Todo/`
+`<workspace>/Social/Content/Todo/`
 
 Select one post file.
 
@@ -101,7 +101,7 @@ If the post file includes a specified submolt, use it.
 If not:
 
 1. Read the lane file in:
-   `{baseDir}/Social/Content/Lanes/`
+   `<workspace>/Social/Content/Lanes/`
 2. Determine appropriate submolt based on:
    - Topic
    - Tone
@@ -152,11 +152,11 @@ After successful publish:
 1. Add post URL to file frontmatter or bottom.
 2. Move file from:
 
-`{baseDir}/Social/Content/Todo/`
+`<workspace>/Social/Content/Todo/`
 
 to:
 
-`{baseDir}/Social/Content/Done/`
+`<workspace>/Social/Content/Done/`
 
 Preserve filename.
 
@@ -166,7 +166,7 @@ Preserve filename.
 
 Append to:
 
-`{baseDir}/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
 
 Format:
 

--- a/references/roles/Researcher.md
+++ b/references/roles/Researcher.md
@@ -20,10 +20,10 @@ This role produces strategic guidance — not content.
 In the social workspace:
 
 Primary output:
-`{baseDir}/Social/Guidance/README.md`
+`<workspace>/Social/Guidance/README.md`
 
 Secondary output:
-`{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
 
 ---
 
@@ -69,7 +69,7 @@ Research must compound, not sprawl.
 
 Persistent task file:
 
-`{baseDir}/Social/Guidance/Research-Tasks.md`
+`<workspace>/Social/Guidance/Research-Tasks.md`
 
 If it does not exist, create it.
 
@@ -142,7 +142,7 @@ The goal is pattern detection.
 
 All durable findings should be distilled into:
 
-`{baseDir}/Social/Guidance/README.md`
+`<workspace>/Social/Guidance/README.md`
 
 This file becomes:
 
@@ -182,11 +182,11 @@ Only add findings that:
 
 Each run appends to:
 
-`{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
 
 Full path:
 
-`{baseDir}/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
 
 Log format:
 
@@ -265,8 +265,8 @@ Others walk it.
 
 Researcher must review:
 
-- `{baseDir}/Social/Submolts/Candidates.md`
-- `{baseDir}/Social/Submolts/Primary.md`
+- `<workspace>/Social/Submolts/Candidates.md`
+- `<workspace>/Social/Submolts/Primary.md`
 
 Researcher may:
 

--- a/references/roles/Responder.md
+++ b/references/roles/Responder.md
@@ -32,7 +32,7 @@ It protects and strengthens relationships.
 
 Social workspace root:
 
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 Moltbook interactions must use:
 
@@ -139,11 +139,11 @@ We are building presence, not chasing approval.
 
 Each run appends to:
 
-`{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
 
 Full path:
 
-`{baseDir}/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
 
 If the file does not exist for the current date, create it.
 
@@ -233,7 +233,7 @@ Just signal.
 Before checking replies and DMs, the Responder should:
 
 1. Read the most recent Scout log file in:
-   `{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+   `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
 2. Review any "Routing Suggestions" that include:
    - Responder
    - Monitor thread

--- a/references/roles/Scout.md
+++ b/references/roles/Scout.md
@@ -48,7 +48,7 @@ This is short-cycle intelligence.
 - Recent post velocity patterns
 
 Social workspace root:
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 ---
 
@@ -80,7 +80,7 @@ Social workspace root:
 
 Scout writes to:
 
-`{baseDir}/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
 
 Format:
 
@@ -169,17 +169,17 @@ Timing improves influence.
 
 Scout must read the following before each run:
 
-- `{baseDir}/Social/Guidance/README.md`
-- `{baseDir}/Social/Content/Lanes/`
-- `{baseDir}/Social/Submolts/Primary.md`
-- `{baseDir}/Social/Submolts/Candidates.md`
+- `<workspace>/Social/Guidance/README.md`
+- `<workspace>/Social/Content/Lanes/`
+- `<workspace>/Social/Submolts/Primary.md`
+- `<workspace>/Social/Submolts/Candidates.md`
 
 Scout should identify up to **3 new candidate submolts per run**.
 
 For each candidate:
 
 - Ensure it is not already in Primary.md or Candidates.md
-- Add to `{baseDir}/Social/Submolts/Candidates.md`
+- Add to `<workspace>/Social/Submolts/Candidates.md`
 
 Format:
 

--- a/references/roles/Writer.md
+++ b/references/roles/Writer.md
@@ -23,24 +23,24 @@ It writes.
 ## 2. Primary Inputs
 
 Social workspace root:
-`{baseDir}/Social/`
+`<workspace>/Social/`
 
 The Writer must review:
 
-1. `{baseDir}/Social/Content/Lanes/` — pick **one lane per run**
-2. `{baseDir}/Social/Content/Todo/` — check current queue depth
-3. `{baseDir}/Social/Submolts/Primary.md` — for target submolt selection
+1. `<workspace>/Social/Content/Lanes/` — pick **one lane per run**
+2. `<workspace>/Social/Content/Todo/` — check current queue depth
+3. `<workspace>/Social/Submolts/Primary.md` — for target submolt selection
 4. Recent Research logs — for topical context
 
 Writer memory:
 
-- **Always** read `{baseDir}/Social/Content/Memory/writer.md` — this is the Writer's long-term memory of themes explored, angles tried, and creative direction.
-- Read the last 3 days of `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md` daily logs for recent context.
+- **Always** read `<workspace>/Social/Content/Memory/writer.md` — this is the Writer's long-term memory of themes explored, angles tried, and creative direction.
+- Read the last 3 days of `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` daily logs for recent context.
 - Use memory to **avoid repeating** the same takes and to **build on** prior content — evolve ideas, deepen threads, find new angles on familiar themes.
 
 Optional local content references (human-configurable):
 
-- If present, read `{baseDir}/Social/Guidance/Local-File-References.md`.
+- If present, read `<workspace>/Social/Guidance/Local-File-References.md`.
 - Treat it as a curated list of local files/directories that may inform post drafting.
 - Only read items that exist and are accessible in the current environment.
 - Skip missing paths without failing the run; note skips in the Writer log.
@@ -64,7 +64,7 @@ One lane. Focus. Quality.
 
 ## 4. Queue Management
 
-Before writing, the Writer checks `{baseDir}/Social/Content/Todo/`.
+Before writing, the Writer checks `<workspace>/Social/Content/Todo/`.
 
 Rules:
 
@@ -86,15 +86,15 @@ The goal is a balanced, steady pipeline — not a flood.
 
 ### Step 2 — Select Lane
 
-- Review active lanes in `{baseDir}/Social/Content/Lanes/`
+- Review active lanes in `<workspace>/Social/Content/Lanes/`
 - Pick the lane that most needs content (fewest queued items, best strategic fit)
 
 ### Step 3 — Gather Context
 
-- Read `{baseDir}/Social/Content/Memory/writer.md` (long-term memory)
-- Read the last 3 days of `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md`
+- Read `<workspace>/Social/Content/Memory/writer.md` (long-term memory)
+- Read the last 3 days of `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md`
 - Read the selected lane definition
-- Read `{baseDir}/Social/Guidance/Local-File-References.md` if present
+- Read `<workspace>/Social/Guidance/Local-File-References.md` if present
 - Read listed local references relevant to the chosen lane
 - Scan recent Research logs for topical inspiration
 - Use memory to identify what's been covered recently and find fresh angles
@@ -103,7 +103,7 @@ The goal is a balanced, steady pipeline — not a flood.
 
 Create new post files in:
 
-`{baseDir}/Social/Content/Todo/`
+`<workspace>/Social/Content/Todo/`
 
 Each post should:
 
@@ -128,13 +128,13 @@ Identity must remain consistent.
 
 After drafting, update the Writer's memory:
 
-1. **Daily log** — append to `{baseDir}/Social/Content/Memory/writer-YYYY-MM-DD.md`:
+1. **Daily log** — append to `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md`:
    - What lane was selected and why
    - What posts were drafted (titles/themes, not full content)
    - What angles or ideas came up that could be explored later
    - What didn't work or felt stale
 
-2. **Long-term memory** — update `{baseDir}/Social/Content/Memory/writer.md` if this run produced insights worth keeping:
+2. **Long-term memory** — update `<workspace>/Social/Content/Memory/writer.md` if this run produced insights worth keeping:
    - Themes that resonate or are evolving
    - Angles that feel exhausted
    - Creative directions to explore next
@@ -148,7 +148,7 @@ The long-term memory file should stay concise — distill, don't dump. Remove st
 
 Each file:
 
-`{baseDir}/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
+`<workspace>/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
 
 Frontmatter example:
 
@@ -196,7 +196,7 @@ It fills the pipeline with quality drafts.
 
 Each run appends to:
 
-`{baseDir}/Social/Content/Logs/Writer-YYYY-MM-DD.md`
+`<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
 
 Log format:
 


### PR DESCRIPTION
## Summary
- Replaced Social runtime path references from `{baseDir}/Social/...` to `<workspace>/Social/...` across skill docs and role references.
- Updated path-conventions guidance to clearly separate skill-owned `{baseDir}` files from workspace-scoped runtime Social artifacts.

## Why
Runtime Social data under `{baseDir}/Social` can be wiped during `clawhub update social-ops` when the installed skill directory is refreshed.

## Affected role/subsystem
- Social Ops runtime data handling and role docs (Scout, Researcher, Content Specialist, Writer, Poster, Responder, Analyst)
- Role I/O map and local reference template

## Feedback-loop implications
- Artifact flow is unchanged semantically; only storage location is updated to workspace scope.
- Existing automations/agents should now read/write runtime artifacts under `<workspace>/Social/...` to preserve continuity across updates.

## Validation
- Verified no remaining `{baseDir}/Social` references in `SKILL.md`, `references/**`, `docs/**`, and `AGENTS.md` via grep.
- Doc-only change; no code tests required.

Closes #49
