### PR TITLE
Remove draft concept; Writer produces final posts directly

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -20,10 +20,11 @@ stage in the pipeline.
 ## Workflow
 
 ```
-Scout ──→ Content Specialist  (new opportunities → drafts)
+Scout ──→ Content Specialist  (new opportunities → lane strategy)
 Scout ──→ Responder           (reply-worthy threads → responses)
-Researcher ──→ guidance for Content Specialist & Responder
-Content Specialist ──→ Poster (finished drafts → published)
+Researcher ──→ guidance for Content Specialist & Writer
+Content Specialist ──→ Writer (lanes → final posts)
+Writer ──→ Poster             (finished posts → published)
 Poster ──→ done logs          (published → archived)
 Analyst ──→ strategy adjustments (performance data → tuning)
 ```
@@ -38,7 +39,7 @@ When dispatched to a role, read its reference doc fully before acting.
 | **Researcher** | `{baseDir}/references/roles/Researcher.md` | Deep-dive into topics, trends, and competitor activity. Produce guidance that informs content and responses. |
 | **Content Specialist** | `{baseDir}/references/roles/Content-Specialist.md` | Convert intelligence and strategy into a content backlog. Define lanes, cadence, and messaging. Does not post. |
 | **Responder** | `{baseDir}/references/roles/Responder.md` | Craft replies to threads surfaced by Scout. Match voice, add value, stay on-brand. |
-| **Poster** | `{baseDir}/references/roles/Poster.md` | Publish finished drafts to the platform. Move completed items to done logs. No ideation, no rewriting. |
+| **Poster** | `{baseDir}/references/roles/Poster.md` | Publish finished posts to the platform. Move completed items to done logs. No ideation, no rewriting. |
 | **Analyst** | `{baseDir}/references/roles/Analyst.md` | Measure performance, identify what compounds, recommend strategy adjustments. Runs weekly minimum. |
 
 ## Dispatching a Role

--- a/references/ROLE-IO-MAP.md
+++ b/references/ROLE-IO-MAP.md
@@ -69,7 +69,7 @@ Analyst recommendations ──> Content Specialist + Researcher
   - `<workspace>/Social/Submolts/Candidates.md` (removals after promotion)
   - `<workspace>/Social/Submolts/Retired.md` (retired submolts)
 - Primary consumers:
-  - Writer (drafts posts based on lanes)
+  - Writer (writes final posts based on lanes)
   - Analyst (evaluates lane/post pipeline performance)
 
 ## Writer

--- a/references/crons/InstallCrons.md
+++ b/references/crons/InstallCrons.md
@@ -50,7 +50,7 @@ Use this prompt when you want to hand-craft your own schedule while preserving r
 > - Responder: meaningful replies only; 1–3 sentences; max one Scout insertion.
 > - Scout: opportunities only; max 3 opportunities/run; no engagement actions.
 > - Content Specialist: lane clarity + strategy only; does not write posts.
-> - Writer: one lane per run; check queue depth; draft 1–4 posts max; skip if queue full.
+> - Writer: one lane per run; check queue depth; write 1–4 final posts max; skip if queue full.
 > - Researcher: 1–3 research tasks + up to 0–2 follow-ups.
 > - Analyst: weekly pattern analysis only; avoid overfitting to single-post spikes.
 > 

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -26,6 +26,8 @@ It does not research trends deeply.
 
 It shapes the strategy. The Writer executes it.
 
+**Important:** The Content Specialist manages lanes about real topics and audiences — not about the social-ops skill itself or the pipeline process. The only exception is if a lane explicitly covers the social-ops project as a topic.
+
 ---
 
 ## 2. Primary Inputs
@@ -128,7 +130,7 @@ After lane adjustments, verify that:
 - Lane frequency targets are up to date
 - `<workspace>/Social/Submolts/Primary.md` is current (for Writer submolt targeting)
 
-The Content Specialist does not generate posts — the Writer handles post drafting based on the lanes and guidance the Content Specialist maintains.
+The Content Specialist does not generate posts — the Writer writes final posts based on the lanes and guidance the Content Specialist maintains.
 
 ---
 
@@ -201,7 +203,7 @@ Keep logs concise.
 A successful Content Specialist run results in:
 
 * Clear lane alignment
-* Lanes ready for the Writer to draft against
+* Lanes ready for the Writer to produce posts against
 * Strategic coherence
 * Forward motion toward growth
 

--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -9,7 +9,7 @@ scope: execution
 
 The Poster executes.
 
-It takes finished post drafts from:
+It takes finished posts from:
 
 `<workspace>/Social/Content/Todo/`
 
@@ -203,7 +203,7 @@ Keep logs concise.
 
 Poster does not:
 
-- Generate new drafts
+- Generate new posts
 - Modify Research tasks
 - Engage in comments
 - Change cadence

--- a/references/roles/Scout.md
+++ b/references/roles/Scout.md
@@ -108,7 +108,7 @@ Suggested Routing:
 
 ---
 
-Scout does not write full drafts.
+Scout does not write posts.
 Scout writes opportunity notes.
 
 ---

--- a/references/roles/Writer.md
+++ b/references/roles/Writer.md
@@ -1,15 +1,18 @@
 ---
 role: Writer
-scope: post-drafting
+scope: post-writing
 ---
 
 # Role: Writer
 
 ## 1. Purpose
 
-The Writer drafts posts for the content pipeline.
+The Writer produces finished, ready-to-publish posts for the content pipeline.
 
-It takes lanes defined by the Content Specialist and produces ready-to-post items in the Todo queue.
+It takes lanes defined by the Content Specialist and creates final posts in the Todo queue.
+
+There is no draft stage. Posts go from the Writer directly to the Poster.
+Every post the Writer creates must be publishable as-is.
 
 It does not manage lanes.
 It does not promote or retire submolts.
@@ -17,6 +20,8 @@ It does not post.
 It does not reply.
 
 It writes.
+
+**Important:** The Writer writes about the topics defined in its lanes — not about the social-ops skill itself, not about the pipeline, and not about its own process. The only exception is if a lane explicitly covers the social-ops project as a topic.
 
 ---
 
@@ -70,7 +75,7 @@ Rules:
 
 - If the Todo queue already has **8+ items total**, do not write. Log the skip and exit cleanly.
 - If the selected lane already has **3+ items** in Todo, pick a different lane or skip. Do not overfill any single lane.
-- The Writer decides how many posts to draft (1–4 per run) based on queue state.
+- The Writer decides how many posts to write (1–4 per run) based on queue state.
 
 The goal is a balanced, steady pipeline — not a flood.
 
@@ -99,7 +104,7 @@ The goal is a balanced, steady pipeline — not a flood.
 - Scan recent Research logs for topical inspiration
 - Use memory to identify what's been covered recently and find fresh angles
 
-### Step 4 — Draft Posts
+### Step 4 — Write Posts
 
 Create new post files in:
 
@@ -109,8 +114,8 @@ Each post should:
 
 - Belong to the selected lane
 - Have a clear thesis
-- Include draft body
-- Be ready for Poster refinement
+- Include the full post body
+- Be ready for Poster to publish as-is
 - Have a compelling opening hook
 - Specify target submolt(s) from Primary.md
 
@@ -126,11 +131,11 @@ Identity must remain consistent.
 
 ### Step 5 — Update Memory
 
-After drafting, update the Writer's memory:
+After writing, update the Writer's memory:
 
 1. **Daily log** — append to `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md`:
    - What lane was selected and why
-   - What posts were drafted (titles/themes, not full content)
+   - What posts were written (titles/themes, not full content)
    - What angles or ideas came up that could be explored later
    - What didn't work or felt stale
 
@@ -188,7 +193,7 @@ The Writer does not:
 * Perform analytics
 * Rewrite strategy or guidance
 
-It fills the pipeline with quality drafts.
+It fills the pipeline with quality, publish-ready posts.
 
 ---
 


### PR DESCRIPTION
Closes #55

## Changes

**Core:** Eliminates the "draft" concept entirely. The Writer now produces **finished, publish-ready posts** that go straight to the Poster — no intermediate draft stage.

**Content Specialist** is explicitly scoped to lane management only (no writing).

**Anti-meta guardrail** added to both Writer and Content Specialist: roles write about their *lane topics*, not about the social-ops skill/pipeline itself (unless that's explicitly a lane).

### Files changed (7)
- `SKILL.md` — updated workflow diagram (CS → Writer → Poster) and role table
- `Writer.md` — draft → final post language throughout, added anti-meta rule
- `Content-Specialist.md` — reinforced lane-only scope, added anti-meta rule
- `Poster.md` — "finished post drafts" → "finished posts"
- `ROLE-IO-MAP.md` — updated CS→Writer consumer description
- `Scout.md` — minor draft terminology cleanup
- `InstallCrons.md` — draft → final post in cron guidance