### PR TITLE
social-ops: Add human configuration guide and fix Poster role order of operations

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -89,3 +89,13 @@ For setting up automated execution of social-media roles, see [references/crons/
 Use one of these paths:
 - **Basic install:** run `./packaged-scripts/install-cron-jobs.sh` from this repo root.
 - **Custom install/tuning:** use `scripts/install-cron-jobs.sh` and `references/crons/InstallCrons.md` as templates, preserving `{baseDir}` conventions and role boundaries.
+
+## Human Configuration
+
+For human-based configuration of the skill, see [references/configuration/Human-Guide.md](references/configuration/Human-Guide.md).
+
+This guide helps users:
+- Specify content directories to read
+- Define social media goals
+- Set up guardrails and rules
+- Configure the Content Specialist to work with user-provided content

--- a/references/configuration/Human-Guide.md
+++ b/references/configuration/Human-Guide.md
@@ -1,0 +1,92 @@
+# Human Configuration Guide for Social Ops Skill
+
+This guide helps users configure the social-ops skill for their specific needs and content.
+
+## Overview
+
+The social-ops skill is designed to be flexible and adaptable to different content sources, social media goals, and operational guardrails. This guide walks you through the key configuration points.
+
+## 1. Content Directories
+
+The skill operates on content directories that contain your social media materials. By default, these are located in your OpenClaw workspace under `Social/`.
+
+### Default Structure
+
+```
+<workspace>/Social/
+├── Content/
+│   ├── Lanes/       # Lane definitions
+│   ├── Todo/        # Pending posts
+│   ├── Done/        # Published posts
+│   └── Logs/        # Activity logs
+├── Guidance/        # Strategy and tone guidance
+└── State/           # Runtime state files
+```
+
+### Customizing Content Paths
+
+You can customize these paths by setting environment variables or modifying the skill's configuration. The skill uses `{baseDir}/../Social/` as the default root, but you can adjust this to point to any directory structure that matches the expected layout.
+
+## 2. Social Media Goals
+
+Define your social media goals in `<workspace>/Social/Guidance/README.md`. This file should include:
+
+- Target audience
+- Desired tone and voice
+- Key messaging themes
+- Growth objectives
+- Platform-specific considerations
+
+The Content Specialist and Writer roles will reference this file when creating content.
+
+## 3. Guardrails and Rules
+
+Establish clear guardrails in `<workspace>/Social/Guidance/Guardrails.md`:
+
+- What topics to avoid
+- What language is inappropriate
+- Privacy and confidentiality rules
+- Brand guidelines
+- Legal compliance requirements
+
+All roles should be aware of and遵守 these guardrails.
+
+## 4. Content Specialist Workflow
+
+The Content Specialist role is designed to work with user-provided content directories:
+
+1. It can inspect content directories to understand available materials
+2. It can suggest lane structures based on content themes
+3. It can identify gaps in content coverage
+4. It can propose content strategies based on analysis
+
+To enable this functionality:
+- Ensure your content directories are accessible to the skill
+- Provide clear documentation about content organization
+- Specify any preferred categorization or tagging schemes
+
+## 5. Initial Setup Script
+
+Consider creating a setup script that guides users through the initial configuration:
+
+```bash
+./configure-social-ops.sh
+```
+
+This script could:
+- Prompt for content directory locations
+- Help define initial social media goals
+- Set up the basic directory structure
+- Create template guidance files
+- Install cron jobs for automated execution
+
+## 6. Validation
+
+After configuration, validate that:
+- All required directories exist and are writable
+- Guidance files are in place
+- The skill can access content directories
+- Cron jobs are properly scheduled
+- All roles can execute without errors
+
+Regular validation ensures the system continues to operate smoothly as content and goals evolve.

--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -119,7 +119,6 @@ Never shotgun across multiple submolts.
 Before posting:
 
 - Confirm identity via Moltbook API
-- Solve the moltbook verification puzzle to ensure post authenticity
 - Ensure post:
   - Has a strong opening line
   - Has no placeholder text
@@ -145,9 +144,18 @@ That belongs to Responder.
 
 ---
 
-## 7. Post-Move
+## 7. Verification
 
-After successful publish:
+After publishing:
+
+- Solve the moltbook verification puzzle to ensure post authenticity
+- Confirm the post is visible on the platform
+
+---
+
+## 8. Post-Move
+
+After successful publish and verification:
 
 1. Add post URL to file frontmatter or bottom.
 2. Move file from:


### PR DESCRIPTION
This PR addresses two issues:

1. Closes #57 - Adds a comprehensive human configuration guide that helps users set up the skill with their own content directories, social media goals, and guardrails. The guide also explains how the Content Specialist can work with user-provided content.

2. Closes #39 - Fixes the order of operations in the Poster role by moving the verification step to after publishing, which is the logical order.

Changes made:
- Added references/configuration/Human-Guide.md with detailed configuration instructions
- Updated SKILL.md to reference the new configuration guide
- Fixed the Poster role order of operations in references/roles/Poster.md
- Added a verification step after publishing in the Poster role