### PR TITLE
Replace <workspace>/Social with $SOCIAL_OPS_DATA_DIR env var

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,13 +41,13 @@ your-skill/
 So when making prompts use things such as:
 
 ```
-Open the file found in <workspace>/Social/roles/
+Open the file found in $SOCIAL_OPS_DATA_DIR/roles/
 ```
 
 or
 
 ```
-Look for recent files in <workspace>/Social/Content
+Look for recent files in $SOCIAL_OPS_DATA_DIR/Content
 ```
 
 ---

--- a/SKILL.md
+++ b/SKILL.md
@@ -61,13 +61,32 @@ Role-to-role artifact flow and logging ownership are documented in:
 
 - `{baseDir}/references/ROLE-IO-MAP.md`
 
+## Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `SOCIAL_OPS_DATA_DIR` | **Yes** | Absolute path to the `Social/` data directory where runtime artifacts live (logs, lanes, guidance, todo/done queues, submolts, memory). |
+
+### Setup
+
+Before any role can run, `SOCIAL_OPS_DATA_DIR` must be set. If it is not set:
+
+1. **Ask the operator** where their Social data directory lives.
+2. Recommend they add it to their shell profile:
+
+```bash
+export SOCIAL_OPS_DATA_DIR=/path/to/Social
+```
+
+All role docs reference `$SOCIAL_OPS_DATA_DIR/` as the root for runtime data. This replaces the previous `<workspace>/Social/` convention for reliability.
+
 ## Path Conventions
 
 Use these path rules to keep the skill portable:
 
 - Skill-owned files (docs, scripts, assets): use `{baseDir}/...`
-- Runtime/social data files (logs, guidance, todo/done queues): keep them under `<workspace>/Social/...`.
-- Runtime state files that are not in `Social/` (for example comment watermarks): use the documented state path `{baseDir}/../state/...` until state-location policy changes.
+- Runtime/social data files (logs, guidance, todo/done queues): use `$SOCIAL_OPS_DATA_DIR/...`
+- Runtime state files that are not in the data dir (for example comment watermarks): use the documented state path `{baseDir}/../state/...` until state-location policy changes.
 
 When adding new instructions, do not hardcode machine-specific absolute paths.
 

--- a/docs/PATH-CONVENTIONS.md
+++ b/docs/PATH-CONVENTIONS.md
@@ -25,10 +25,10 @@ Examples:
 Use these locations for role runtime artifacts generated during operation:
 
 - Social runtime data lives in the workspace (outside the installed skill directory):
-  - `<workspace>/Social/Guidance/**`
-  - `<workspace>/Social/Content/Todo/**`
-  - `<workspace>/Social/Content/Done/**`
-  - `<workspace>/Social/Content/Logs/**`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/**`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Todo/**`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Done/**`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/**`
 - Comment watermark state remains at:
   - `{baseDir}/../state/comment-state.json`
 
@@ -38,5 +38,5 @@ Use these locations for role runtime artifacts generated during operation:
 
 - Do not introduce absolute host paths.
 - For packaged skill references, prefer `{baseDir}`.
-- For generated Social runtime artifacts, keep paths under `<workspace>/Social/...`.
+- For generated Social runtime artifacts, keep paths under `$SOCIAL_OPS_DATA_DIR/...`.
 - For known state artifacts, use the documented state path until policy changes.

--- a/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
+++ b/references/LOCAL-FILE-REFERENCES-TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Use this template to create:
 
-`<workspace>/Social/Guidance/Local-File-References.md`
+`$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md`
 
 Purpose:
 - Provide a human-editable list of local files/directories that the **Content Specialist** may read during backlog generation.

--- a/references/ROLE-IO-MAP.md
+++ b/references/ROLE-IO-MAP.md
@@ -24,13 +24,13 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Scout
 - Reads:
   - Moltbook feed/submolts/accounts (platform data)
-  - `<workspace>/Social/Guidance/README.md`
-  - `<workspace>/Social/Content/Lanes/`
-  - `<workspace>/Social/Submolts/Primary.md`
-  - `<workspace>/Social/Submolts/Candidates.md`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
 - Writes:
-  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-  - `<workspace>/Social/Submolts/Candidates.md` (new candidate entries)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md` (new candidate entries)
 - Primary consumers:
   - Responder (thread insertion opportunities)
   - Content Specialist (topic opportunities)
@@ -39,15 +39,15 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Researcher
 - Reads:
   - Moltbook high-performing posts/accounts
-  - `<workspace>/Social/Guidance/Research-Tasks.md` (task queue)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Research-Tasks.md` (task queue)
   - prior research logs
-  - `<workspace>/Social/Submolts/Candidates.md`
-  - `<workspace>/Social/Submolts/Primary.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
 - Writes:
-  - `<workspace>/Social/Guidance/README.md` (durable guidance)
-  - `<workspace>/Social/Guidance/Research-Tasks.md` (task queue updates)
-  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `<workspace>/Social/Submolts/Candidates.md` (analysis notes, additional candidates)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/README.md` (durable guidance)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Research-Tasks.md` (task queue updates)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md` (analysis notes, additional candidates)
 - Primary consumers:
   - Content Specialist (content planning)
   - Poster (tone/check alignment)
@@ -55,50 +55,50 @@ Analyst recommendations ──> Content Specialist + Researcher
 
 ## Content Specialist
 - Reads:
-  - `<workspace>/Social/Guidance/README.md`
-  - `<workspace>/Social/Guidance/Local-File-References.md` (optional, human-curated)
-  - `<workspace>/Social/Content/Lanes/`
-  - recent `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `<workspace>/Social/Submolts/Candidates.md`
-  - `<workspace>/Social/Submolts/Primary.md`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md` (optional, human-curated)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
+  - recent `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
   - local files/directories referenced by `Local-File-References.md` (only if present/accessible)
 - Writes:
-  - `<workspace>/Social/Content/Lanes/*.md` (create/refine/retire lane definitions)
-  - `<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md`
-  - `<workspace>/Social/Submolts/Primary.md` (promotions from Candidates)
-  - `<workspace>/Social/Submolts/Candidates.md` (removals after promotion)
-  - `<workspace>/Social/Submolts/Retired.md` (retired submolts)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/*.md` (create/refine/retire lane definitions)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Content-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md` (promotions from Candidates)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md` (removals after promotion)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Retired.md` (retired submolts)
 - Primary consumers:
   - Writer (writes final posts based on lanes)
   - Analyst (evaluates lane/post pipeline performance)
 
 ## Writer
 - Reads:
-  - `<workspace>/Social/Content/Memory/writer.md` (long-term memory)
-  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (last 3 days)
-  - `<workspace>/Social/Content/Lanes/` (selects one lane per run)
-  - `<workspace>/Social/Content/Todo/` (queue depth check)
-  - `<workspace>/Social/Submolts/Primary.md`
-  - `<workspace>/Social/Guidance/Local-File-References.md` (optional, human-curated)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` (long-term memory)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md` (last 3 days)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/` (selects one lane per run)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Todo/` (queue depth check)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md` (optional, human-curated)
   - local files/directories referenced by `Local-File-References.md` (only if present/accessible)
-  - recent `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+  - recent `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
 - Writes:
-  - `<workspace>/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
-  - `<workspace>/Social/Content/Memory/writer.md` (long-term memory updates)
-  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (daily memory log)
-  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` (long-term memory updates)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md` (daily memory log)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Writer-YYYY-MM-DD.md`
 - Primary consumers:
   - Poster (publishes TODO items)
   - Analyst (evaluates post quality and queue balance)
 
 ## Poster
 - Reads:
-  - `<workspace>/Social/Guidance/README.md`
-  - `<workspace>/Social/Content/Todo/`
-  - `<workspace>/Social/Content/Lanes/`
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Todo/`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
 - Writes:
-  - `<workspace>/Social/Content/Done/` (moves posted file from Todo)
-  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Done/` (moves posted file from Todo)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Poster-YYYY-MM-DD.md`
   - published post URL attached to moved post artifact
 - Primary consumers:
   - Analyst (performance review)
@@ -108,25 +108,25 @@ Analyst recommendations ──> Content Specialist + Researcher
 - Reads:
   - Moltbook replies/DMs/mentions
   - `{baseDir}/../state/comment-state.json`
-  - latest Scout log: `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+  - latest Scout log: `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
 - Writes:
   - `{baseDir}/../state/comment-state.json` (watermarks + seen ids)
-  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md`
 - Primary consumers:
   - Analyst (relational signal quality)
 
 ## Analyst
 - Reads:
-  - `<workspace>/Social/Content/Done/`
-  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
-  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
-  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
-  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
-  - `<workspace>/Social/Submolts/Primary.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Done/`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Poster-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Writer-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
   - Moltbook engagement metrics
 - Writes:
-  - `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md` (includes submolt retirement recommendations)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Analysis-YYYY-WW.md` (includes submolt retirement recommendations)
   - recommendations (consumed by Content Specialist + Researcher)
 - Primary consumers:
   - Content Specialist (lane/cadence changes)
@@ -135,32 +135,32 @@ Analyst recommendations ──> Content Specialist + Researcher
 ## Shared artifact map
 
 - Guidance artifacts:
-  - `<workspace>/Social/Guidance/README.md` (producer: Researcher; consumers: Content Specialist, Poster, Analyst)
-  - `<workspace>/Social/Guidance/Research-Tasks.md` (producer/consumer: Researcher)
-  - `<workspace>/Social/Guidance/Local-File-References.md` (producer: human operator and/or Researcher; consumers: Content Specialist, Writer)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/README.md` (producer: Researcher; consumers: Content Specialist, Poster, Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Research-Tasks.md` (producer/consumer: Researcher)
+  - `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md` (producer: human operator and/or Researcher; consumers: Content Specialist, Writer)
 
 - Pipeline artifacts:
-  - `<workspace>/Social/Content/Todo/` (producer: Writer; consumer: Poster)
-  - `<workspace>/Social/Content/Done/` (producer: Poster; consumer: Analyst)
-  - `<workspace>/Social/Content/Lanes/` (producer: Content Specialist; consumers: Poster, Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Todo/` (producer: Writer; consumer: Poster)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Done/` (producer: Poster; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Lanes/` (producer: Content Specialist; consumers: Poster, Analyst)
 
 - Log artifacts:
-  - `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md` (producer: Scout; consumers: Responder, Analyst)
-  - `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md` (producer: Researcher; consumers: Content Specialist, Analyst)
-  - `<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md` (producer: Content Specialist; consumer: Analyst)
-  - `<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md` (producer: Writer; consumer: Analyst)
-  - `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md` (producer: Poster; consumer: Analyst)
-  - `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md` (producer: Responder; consumer: Analyst)
-  - `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md` (producer: Analyst; consumers: Content Specialist, Researcher)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md` (producer: Scout; consumers: Responder, Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md` (producer: Researcher; consumers: Content Specialist, Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Content-YYYY-MM-DD.md` (producer: Content Specialist; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Writer-YYYY-MM-DD.md` (producer: Writer; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Poster-YYYY-MM-DD.md` (producer: Poster; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md` (producer: Responder; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Logs/Analysis-YYYY-WW.md` (producer: Analyst; consumers: Content Specialist, Researcher)
 
 - Submolt lifecycle artifacts:
-  - `<workspace>/Social/Submolts/Primary.md` (producers: Content Specialist; consumers: Scout, Researcher, Analyst)
-  - `<workspace>/Social/Submolts/Candidates.md` (producers: Scout, Researcher; consumer: Content Specialist)
-  - `<workspace>/Social/Submolts/Retired.md` (producer: Content Specialist; consumer: Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md` (producers: Content Specialist; consumers: Scout, Researcher, Analyst)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md` (producers: Scout, Researcher; consumer: Content Specialist)
+  - `$SOCIAL_OPS_DATA_DIR/Submolts/Retired.md` (producer: Content Specialist; consumer: Analyst)
 
 - Memory artifacts:
-  - `<workspace>/Social/Content/Memory/writer.md` (producer/consumer: Writer; long-term creative memory)
-  - `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` (producer: Writer; consumer: Writer on subsequent runs)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` (producer/consumer: Writer; long-term creative memory)
+  - `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md` (producer: Writer; consumer: Writer on subsequent runs)
 
 - Runtime state artifacts:
   - `{baseDir}/../state/comment-state.json` (producer/consumer: Responder)

--- a/references/roles/Analyst.md
+++ b/references/roles/Analyst.md
@@ -34,15 +34,15 @@ It does not run daily.
 ## 3. Inputs
 
 Social workspace root:
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 Primary data sources:
 
-- `<workspace>/Social/Content/Done/`
-- `<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
-- `<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
-- `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
-- `<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Done/`
+- `$SOCIAL_OPS_DATA_DIR/Content/Logs/Poster-YYYY-MM-DD.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
 - Moltbook engagement metrics (via API)
 
 Metrics to gather:
@@ -97,7 +97,7 @@ For posts in `Done/`:
 
 Analyst writes to:
 
-`<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Analysis-YYYY-WW.md`
 
 Weekly format example:
 
@@ -200,8 +200,8 @@ Analyst must review engagement by submolt during each analysis run.
 
 Inputs:
 
-- `<workspace>/Social/Submolts/Primary.md`
-- `<workspace>/Social/Content/Done/`
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Done/`
 
 Recommend retirement if:
 
@@ -212,5 +212,5 @@ Recommend retirement if:
 **Constraints:**
 
 - Analyst does not directly move submolts.
-- Analyst only recommends — writes recommendations to `<workspace>/Social/Content/Logs/Analysis-YYYY-WW.md`.
+- Analyst only recommends — writes recommendations to `$SOCIAL_OPS_DATA_DIR/Content/Logs/Analysis-YYYY-WW.md`.
 - Content Specialist acts on retirement recommendations.

--- a/references/roles/Content-Specialist.md
+++ b/references/roles/Content-Specialist.md
@@ -33,20 +33,20 @@ It shapes the strategy. The Writer executes it.
 ## 2. Primary Inputs
 
 Social workspace root:
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 The Content Specialist must review:
 
-1. `<workspace>/Social/Guidance/README.md`
-2. `<workspace>/Social/Content/Lanes/`
-3. `<workspace>/Social/Submolts/Primary.md`
+1. `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+2. `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
+3. `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
 4. Recent Research logs
 
 Before adjusting lanes or guidance.
 
 Optional local content references (human-configurable):
 
-- If present, read `<workspace>/Social/Guidance/Local-File-References.md`.
+- If present, read `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md`.
 - Treat it as a curated list of local files/directories that may inform lane strategy.
 - Only read items that exist and are accessible in the current environment.
 - Skip missing paths without failing the run; note skips in the Content log.
@@ -57,7 +57,7 @@ Optional local content references (human-configurable):
 
 Lane files live in:
 
-`<workspace>/Social/Content/Lanes/`
+`$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
 
 Each lane file should define:
 
@@ -111,7 +111,7 @@ On each run:
 - Read Guidance README
 - Scan active lanes
 - Review recent Research logs
-- If `<workspace>/Social/Guidance/Local-File-References.md` exists:
+- If `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md` exists:
   - Read listed local references (files/directories) that exist.
   - Use them as optional context inputs for lane strategy decisions.
   - Record any missing/unreadable configured references in the run log.
@@ -128,7 +128,7 @@ After lane adjustments, verify that:
 
 - Active lanes have clear definitions the Writer can act on
 - Lane frequency targets are up to date
-- `<workspace>/Social/Submolts/Primary.md` is current (for Writer submolt targeting)
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md` is current (for Writer submolt targeting)
 
 The Content Specialist does not generate posts — the Writer writes final posts based on the lanes and guidance the Content Specialist maintains.
 
@@ -139,7 +139,7 @@ The Content Specialist does not generate posts — the Writer writes final posts
 New lane ideas may come from:
 
 * High-performing patterns in Research guidance
-* Recurring themes from configured local references in `<workspace>/Social/Guidance/Local-File-References.md`
+* Recurring themes from configured local references in `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md`
 * Emerging projects/artifacts from local references
 * Strong creative concepts appearing repeatedly
 
@@ -169,7 +169,7 @@ It shapes the pipeline. The Writer fills it.
 
 Each run appends to:
 
-`<workspace>/Social/Content/Logs/Content-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Content-YYYY-MM-DD.md`
 
 Log format:
 
@@ -221,7 +221,7 @@ The Content Specialist owns submolt lifecycle transitions.
 
 ### Regular Tasks
 
-- Ensure the agent is subscribed to all submolts listed in `<workspace>/Social/Submolts/Primary.md`.
+- Ensure the agent is subscribed to all submolts listed in `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`.
 - Mark checkboxes for subscribed submolts in Primary.md.
 
 ### Promotion (Candidates → Primary)
@@ -231,21 +231,21 @@ Rules:
 - May promote up to **2 submolts per day** from Candidates → Primary.
 - Must base decision on:
   - Researcher notes in Candidates.md
-  - Guidance alignment (`<workspace>/Social/Guidance/README.md`)
-  - Lane relevance (`<workspace>/Social/Content/Lanes/`)
+  - Guidance alignment (`$SOCIAL_OPS_DATA_DIR/Guidance/README.md`)
+  - Lane relevance (`$SOCIAL_OPS_DATA_DIR/Content/Lanes/`)
 
 Steps:
 
-1. Move the entry from `<workspace>/Social/Submolts/Candidates.md`
-2. Add to `<workspace>/Social/Submolts/Primary.md`
+1. Move the entry from `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
+2. Add to `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
 3. Remove from Candidates.md
 
 ### Retirement (Primary → Retired)
 
 If a submolt underperforms or misaligns:
 
-1. Move from `<workspace>/Social/Submolts/Primary.md`
-2. Append to `<workspace>/Social/Submolts/Retired.md`
+1. Move from `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
+2. Append to `$SOCIAL_OPS_DATA_DIR/Submolts/Retired.md`
 
 Format in Retired.md:
 

--- a/references/roles/Poster.md
+++ b/references/roles/Poster.md
@@ -11,13 +11,13 @@ The Poster executes.
 
 It takes finished posts from:
 
-`<workspace>/Social/Content/Todo/`
+`$SOCIAL_OPS_DATA_DIR/Content/Todo/`
 
 Publishes them to Moltbook.
 
 Moves them to:
 
-`<workspace>/Social/Content/Done/`
+`$SOCIAL_OPS_DATA_DIR/Content/Done/`
 
 It does not ideate.
 It does not research.
@@ -32,13 +32,13 @@ It publishes with confidence.
 
 Social workspace root:
 
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 Primary inputs:
 
-- `<workspace>/Social/Guidance/README.md`
-- `<workspace>/Social/Content/Todo/`
-- Lane definitions in `<workspace>/Social/Content/Lanes/`
+- `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Todo/`
+- Lane definitions in `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
 
 Moltbook interactions must use documented Moltbook skill patterns.
 
@@ -66,7 +66,7 @@ Consistency > burst posting.
 
 Briefly review:
 
-`<workspace>/Social/Guidance/README.md`
+`$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
 
 This ensures:
 - Tone alignment
@@ -82,7 +82,7 @@ Just align tone and structure.
 
 Scan:
 
-`<workspace>/Social/Content/Todo/`
+`$SOCIAL_OPS_DATA_DIR/Content/Todo/`
 
 Select one post file.
 
@@ -101,7 +101,7 @@ If the post file includes a specified submolt, use it.
 If not:
 
 1. Read the lane file in:
-   `<workspace>/Social/Content/Lanes/`
+   `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
 2. Determine appropriate submolt based on:
    - Topic
    - Tone
@@ -152,11 +152,11 @@ After successful publish:
 1. Add post URL to file frontmatter or bottom.
 2. Move file from:
 
-`<workspace>/Social/Content/Todo/`
+`$SOCIAL_OPS_DATA_DIR/Content/Todo/`
 
 to:
 
-`<workspace>/Social/Content/Done/`
+`$SOCIAL_OPS_DATA_DIR/Content/Done/`
 
 Preserve filename.
 
@@ -166,7 +166,7 @@ Preserve filename.
 
 Append to:
 
-`<workspace>/Social/Content/Logs/Poster-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Poster-YYYY-MM-DD.md`
 
 Format:
 

--- a/references/roles/Researcher.md
+++ b/references/roles/Researcher.md
@@ -20,10 +20,10 @@ This role produces strategic guidance — not content.
 In the social workspace:
 
 Primary output:
-`<workspace>/Social/Guidance/README.md`
+`$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
 
 Secondary output:
-`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
 
 ---
 
@@ -69,7 +69,7 @@ Research must compound, not sprawl.
 
 Persistent task file:
 
-`<workspace>/Social/Guidance/Research-Tasks.md`
+`$SOCIAL_OPS_DATA_DIR/Guidance/Research-Tasks.md`
 
 If it does not exist, create it.
 
@@ -142,7 +142,7 @@ The goal is pattern detection.
 
 All durable findings should be distilled into:
 
-`<workspace>/Social/Guidance/README.md`
+`$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
 
 This file becomes:
 
@@ -182,11 +182,11 @@ Only add findings that:
 
 Each run appends to:
 
-`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
 
 Full path:
 
-`<workspace>/Social/Content/Logs/Research-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Research-YYYY-MM-DD.md`
 
 Log format:
 
@@ -265,8 +265,8 @@ Others walk it.
 
 Researcher must review:
 
-- `<workspace>/Social/Submolts/Candidates.md`
-- `<workspace>/Social/Submolts/Primary.md`
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
 
 Researcher may:
 

--- a/references/roles/Responder.md
+++ b/references/roles/Responder.md
@@ -32,7 +32,7 @@ It protects and strengthens relationships.
 
 Social workspace root:
 
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 Moltbook interactions must use:
 
@@ -139,11 +139,11 @@ We are building presence, not chasing approval.
 
 Each run appends to:
 
-`<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md`
 
 Full path:
 
-`<workspace>/Social/Content/Logs/Responder-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Responder-YYYY-MM-DD.md`
 
 If the file does not exist for the current date, create it.
 
@@ -233,7 +233,7 @@ Just signal.
 Before checking replies and DMs, the Responder should:
 
 1. Read the most recent Scout log file in:
-   `<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+   `$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
 2. Review any "Routing Suggestions" that include:
    - Responder
    - Monitor thread

--- a/references/roles/Scout.md
+++ b/references/roles/Scout.md
@@ -48,7 +48,7 @@ This is short-cycle intelligence.
 - Recent post velocity patterns
 
 Social workspace root:
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 ---
 
@@ -80,7 +80,7 @@ Social workspace root:
 
 Scout writes to:
 
-`<workspace>/Social/Content/Logs/Scout-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Scout-YYYY-MM-DD.md`
 
 Format:
 
@@ -169,17 +169,17 @@ Timing improves influence.
 
 Scout must read the following before each run:
 
-- `<workspace>/Social/Guidance/README.md`
-- `<workspace>/Social/Content/Lanes/`
-- `<workspace>/Social/Submolts/Primary.md`
-- `<workspace>/Social/Submolts/Candidates.md`
+- `$SOCIAL_OPS_DATA_DIR/Guidance/README.md`
+- `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md`
+- `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
 
 Scout should identify up to **3 new candidate submolts per run**.
 
 For each candidate:
 
 - Ensure it is not already in Primary.md or Candidates.md
-- Add to `<workspace>/Social/Submolts/Candidates.md`
+- Add to `$SOCIAL_OPS_DATA_DIR/Submolts/Candidates.md`
 
 Format:
 

--- a/references/roles/Writer.md
+++ b/references/roles/Writer.md
@@ -28,24 +28,24 @@ It writes.
 ## 2. Primary Inputs
 
 Social workspace root:
-`<workspace>/Social/`
+`$SOCIAL_OPS_DATA_DIR/`
 
 The Writer must review:
 
-1. `<workspace>/Social/Content/Lanes/` — pick **one lane per run**
-2. `<workspace>/Social/Content/Todo/` — check current queue depth
-3. `<workspace>/Social/Submolts/Primary.md` — for target submolt selection
+1. `$SOCIAL_OPS_DATA_DIR/Content/Lanes/` — pick **one lane per run**
+2. `$SOCIAL_OPS_DATA_DIR/Content/Todo/` — check current queue depth
+3. `$SOCIAL_OPS_DATA_DIR/Submolts/Primary.md` — for target submolt selection
 4. Recent Research logs — for topical context
 
 Writer memory:
 
-- **Always** read `<workspace>/Social/Content/Memory/writer.md` — this is the Writer's long-term memory of themes explored, angles tried, and creative direction.
-- Read the last 3 days of `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md` daily logs for recent context.
+- **Always** read `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` — this is the Writer's long-term memory of themes explored, angles tried, and creative direction.
+- Read the last 3 days of `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md` daily logs for recent context.
 - Use memory to **avoid repeating** the same takes and to **build on** prior content — evolve ideas, deepen threads, find new angles on familiar themes.
 
 Optional local content references (human-configurable):
 
-- If present, read `<workspace>/Social/Guidance/Local-File-References.md`.
+- If present, read `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md`.
 - Treat it as a curated list of local files/directories that may inform post drafting.
 - Only read items that exist and are accessible in the current environment.
 - Skip missing paths without failing the run; note skips in the Writer log.
@@ -69,7 +69,7 @@ One lane. Focus. Quality.
 
 ## 4. Queue Management
 
-Before writing, the Writer checks `<workspace>/Social/Content/Todo/`.
+Before writing, the Writer checks `$SOCIAL_OPS_DATA_DIR/Content/Todo/`.
 
 Rules:
 
@@ -91,15 +91,15 @@ The goal is a balanced, steady pipeline — not a flood.
 
 ### Step 2 — Select Lane
 
-- Review active lanes in `<workspace>/Social/Content/Lanes/`
+- Review active lanes in `$SOCIAL_OPS_DATA_DIR/Content/Lanes/`
 - Pick the lane that most needs content (fewest queued items, best strategic fit)
 
 ### Step 3 — Gather Context
 
-- Read `<workspace>/Social/Content/Memory/writer.md` (long-term memory)
-- Read the last 3 days of `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md`
+- Read `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` (long-term memory)
+- Read the last 3 days of `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md`
 - Read the selected lane definition
-- Read `<workspace>/Social/Guidance/Local-File-References.md` if present
+- Read `$SOCIAL_OPS_DATA_DIR/Guidance/Local-File-References.md` if present
 - Read listed local references relevant to the chosen lane
 - Scan recent Research logs for topical inspiration
 - Use memory to identify what's been covered recently and find fresh angles
@@ -108,7 +108,7 @@ The goal is a balanced, steady pipeline — not a flood.
 
 Create new post files in:
 
-`<workspace>/Social/Content/Todo/`
+`$SOCIAL_OPS_DATA_DIR/Content/Todo/`
 
 Each post should:
 
@@ -133,13 +133,13 @@ Identity must remain consistent.
 
 After writing, update the Writer's memory:
 
-1. **Daily log** — append to `<workspace>/Social/Content/Memory/writer-YYYY-MM-DD.md`:
+1. **Daily log** — append to `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer-YYYY-MM-DD.md`:
    - What lane was selected and why
    - What posts were written (titles/themes, not full content)
    - What angles or ideas came up that could be explored later
    - What didn't work or felt stale
 
-2. **Long-term memory** — update `<workspace>/Social/Content/Memory/writer.md` if this run produced insights worth keeping:
+2. **Long-term memory** — update `$SOCIAL_OPS_DATA_DIR/Content/Memory/writer.md` if this run produced insights worth keeping:
    - Themes that resonate or are evolving
    - Angles that feel exhausted
    - Creative directions to explore next
@@ -153,7 +153,7 @@ The long-term memory file should stay concise — distill, don't dump. Remove st
 
 Each file:
 
-`<workspace>/Social/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Todo/YYYY-MM-DD-XX-LaneName.md`
 
 Frontmatter example:
 
@@ -201,7 +201,7 @@ It fills the pipeline with quality, publish-ready posts.
 
 Each run appends to:
 
-`<workspace>/Social/Content/Logs/Writer-YYYY-MM-DD.md`
+`$SOCIAL_OPS_DATA_DIR/Content/Logs/Writer-YYYY-MM-DD.md`
 
 Log format:
 


### PR DESCRIPTION
Closes #59

Replaces all `<workspace>/Social` references with `$SOCIAL_OPS_DATA_DIR` across the entire skill for robust, unambiguous directory resolution.

## Changes

- **SKILL.md** — new Environment Variables section with setup guidance. Agents must check for the env var; if unset, ask the operator or set it themselves.
- **All 7 role docs** — 145 path references updated (`<workspace>/Social/` → `$SOCIAL_OPS_DATA_DIR/`)
- **ROLE-IO-MAP.md** — all artifact paths updated
- **PATH-CONVENTIONS.md, AGENTS.md, LOCAL-FILE-REFERENCES-TEMPLATE.md** — updated to match

### Setup for operators
```bash
export SOCIAL_OPS_DATA_DIR=/path/to/Social
```

No functional changes to role behavior — purely a path convention fix for reliability.